### PR TITLE
Showing Python calltips on every "," of a function call, not only on first "("

### DIFF
--- a/libs/codeintel2/lang_python.py
+++ b/libs/codeintel2/lang_python.py
@@ -966,7 +966,7 @@ class PythonBuffer(CitadelBuffer):
             line = self._last_logical_line(working_text).rstrip()
             if line:
                 last_bracket = line.rfind("(")
-                pos = (pos - (len(line) - last_bracket)) - 1
+                pos = (pos - (len(line) - last_bracket))
                 return Trigger(self.lang, TRG_FORM_CALLTIP,
                                "call-signature", pos, implicit)
             else:


### PR DESCRIPTION
Just a small change that works good for me personally. I always found it problematic that the calltips disappeared after I added the first argument to a function call. With this change, the calltip is displayed on every "," following an "(".
Maybe you want to pull it into the main branch.

Thanks for creating SublimeCodeIntel by the way!
Julian
