### PR TITLE
Issue 17: get_git_revision stops if recursing up gives the same path

### DIFF
--- a/python_codeintel.py
+++ b/python_codeintel.py
@@ -818,5 +818,9 @@ def get_git_revision(path=None):
         rev = _get_git_revision(path)
         if rev:
             return u'GIT-%s' % rev
-        path = os.path.abspath(os.path.join(path, '..'))
+        uppath = os.path.abspath(os.path.join(path, '..'))
+        if uppath != path:
+            path = uppath
+        else:
+            break
     return u'GIT-unknown'


### PR DESCRIPTION
This makes it work on windows machines when get_git_revision recurses up to a root drive directory.
