### PR TITLE
Only react to events in scopes the plugin understands

### DIFF
--- a/python_codeintel.py
+++ b/python_codeintel.py
@@ -244,7 +244,18 @@ def autocomplete(view, timeout, busy_timeout, preemptive=False, args=[], kwargs=
 
 class PythonCodeIntel(sublime_plugin.EventListener):
 
+    langs = ('css', 'django', 'html', 'html5', 'javascript', 'mason', 'nodejs',
+             'perl', 'php', 'python', 'python3', 'rhtml', 'ruby', 'smarty',
+             'tcl', 'templatetoolkit', 'xbl', 'xml', 'xslt', 'xul')
+
+    def check_scope(self, view):
+        loc = view.sel()[0]
+        scope_name = view.scope_name(loc.a)
+        return any(lang in scope_name for lang in PythonCodeIntel.langs)
+
     def on_close(self, view):
+        if not self.check_scope(view):
+            return
         path = view.file_name()
         status_lock.acquire()
         try:
@@ -259,6 +270,8 @@ class PythonCodeIntel(sublime_plugin.EventListener):
         codeintel_cleanup(path)
 
     def on_modified(self, view):
+        if not self.check_scope(view):
+            return
         path = view.file_name()
         lang, _ = os.path.splitext(os.path.basename(view.settings().get('syntax')))
         try:
@@ -286,6 +299,8 @@ class PythonCodeIntel(sublime_plugin.EventListener):
             queue(view, _scan_callback, 3000, args=[path])
 
     def on_selection_modified(self, view):
+        if not self.check_scope(view):
+            return
         global despair, despaired, old_pos
         delay_queue(600)  # on movement, delay queue (to make movement responsive)
 
@@ -303,6 +318,8 @@ class PythonCodeIntel(sublime_plugin.EventListener):
                 calltip(view, "", id=id)
 
     def on_query_completions(self, view, prefix, locations):
+        if not self.check_scope(view):
+            return []
         id = view.id()
         if id in completions:
             _completions = completions[id]


### PR DESCRIPTION
Hi,

It seems that SublimeCodeIntel does not play well with other completion plugins. For some reason it will crash Sublime Text 2 when there are other plugins that implement an EventListener with on_query_completion.
I had this problem when adding more python completions through another plugin. Now I'm working on a plugin that enables Java completions and I get the same crashes (as long as SublimeCodeIntel is installed). 
Other people had the same problem with the Go completion plugin (see http://www.sublimetext.com/forum/viewtopic.php?f=3&t=2798)

One half of the problem can be solved by disabling certain languages in SublimeCodeIntel. But for languages that are not supported (Java, Go) this is not possible.

My suggestion would be to change the EventListener to check the current scope before doing anything (see the pull request).

I'm sure there is a better way to implement this in SublimeCodeIntel, my pull request is just a quicks solution to give you a feel for the problem. The best solution would, of course, be to find the root cause of the crashes, but they happen indeterministic (some kind of race condition).

Greetings,
Julian
