### PR TITLE
README has typo in Configuring Section

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -65,7 +65,7 @@ Configuration files (`~/.codeintel/config` or `project_root/.codeintel/config`).
             "perl": "/usr/bin/perl",
             "perlExtraPaths": []
         },
-        "Perl": {
+        "Ruby": {
             "ruby": "/usr/bin/ruby",
             "rubyExtraPaths": []
         },


### PR DESCRIPTION
Perl is named instead of Ruby in the example configuration file.
