### PR TITLE
Disable hide auto complete

### DIFF
--- a/python_codeintel.py
+++ b/python_codeintel.py
@@ -279,7 +279,7 @@ class PythonCodeIntel(sublime_plugin.EventListener):
             else:
                 # TODO(teejae): re-enable hide_auto_complete after it is correctly made idempotent in Sublime binary.
                 codeintel_log.debug('would use hide_auto_complete')
-                view.run_command('hide_auto_complete')
+                # view.run_command('hide_auto_complete')
         else:
             def _scan_callback(view, path):
                 content = view.substr(sublime.Region(0, view.size()))


### PR DESCRIPTION
Hi,
I believe the bug #28 is caused by a faulty implementation of Sublime's "hide_auto_complete" command. I have reproduced the crashing on a Mac OSX 10.7 and Linux Ubuntu 10.04.

My fix is just to comment out the hide_auto_complete until Sublime gets a correct fix for hide_auto_complete.

Please have a look. Thanks!

Toliver
