### PR TITLE
Updated Readme - If python-dev if not installed, build.sh fails

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -109,6 +109,10 @@ Then simply run:
 
     $ . build.sh
 
+If ``build.sh`` fails - please check that ``python-dev`` is installed
+
+    $ sudo apt-get install python-dev
+
 
 What's New
 ----------


### PR DESCRIPTION
I have added an addition to the readme. After debugging why build.sh failed on ubuntu I found that python.dev had to be installed to stop gcc failing on:

"Python.h: file not found" errors
