### PR TITLE
Fixed typo (trivial)

### DIFF
--- a/Base File.sublime-settings
+++ b/Base File.sublime-settings
@@ -18,7 +18,7 @@
     /*
         Sets the mode in which SublimeCodeIntel's live autocomplete runs:
 
-        true - Autocomplete popsup as you type (the default).
+        true - Autocomplete popups as you type (the default).
         false - Autocomplete popups only when you request it.
     */
     "codeintel_live": true,


### PR DESCRIPTION
Fixed simple typo in Base File.sublime-settings - changed 'popsup' to 'popups'.
