### PR TITLE
"Does not work on Windows"

### DIFF
--- a/libs/codeintel2/lang_css.py
+++ b/libs/codeintel2/lang_css.py
@@ -1109,14 +1109,9 @@ class CSSBuffer(Buffer):
 
 #---- internal support stuff
 
-_ident_chars = string.lowercase + string.uppercase + string.digits + "-"
-_ident_chars_dictionary = {}
-ch = None
-for ch in _ident_chars:
-    _ident_chars_dictionary[ch] = 1
-# Cleanup un-needed namespace definitions
-del ch
-del _ident_chars
+_ident_chars_dictionary = dict( (ch, 1) for ch in 
+                                string.lowercase + string.uppercase + string.digits + "-")
+
 
 def _isident_first_char(char):
     return isident(char) and char != "-" and (char < "0" or char > "9")


### PR DESCRIPTION
I have fixed the '_ident_chars' crash that is mentioned in issue #101.

A module-level loop in lang_css.py that creates "_ident_chars_dictionary" tries to delete loop variables after finishing, but they no longer exist.

I have no idea how this comes about, but replacing the loop with a generator expression removes the need for manual cleanup altogether.
