### PR TITLE
Minor readme cleanup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
 SublimeCodeIntel
 ================
 
-Code intelligence plugin ported from Open Komodo Editor to the `Sublime Text 2 <http://sublimetext.com/dev>`_
+Code intelligence plugin ported from `Open Komodo Editor <http://www.openkomodo.com/>`_ to `Sublime Text 2 <http://www.sublimetext.com/2>`_.
 
-Supports all the languages Komodo Editor supports for Code Intelligence (CIX, CodeIntel2)::
+Supports all the languages Komodo Editor supports for Code Intelligence (CIX, CodeIntel2):
 
     PHP, Python, RHTML, JavaScript, Smarty, Mason, Node.js, XBL, Tcl, HTML, HTML5, TemplateToolkit, XUL, Django, Perl, Ruby, Python3.
 


### PR DESCRIPTION
- Added link for Open Komodo
- Changed link for Sublime Text 2 to the Sublime Text 2 homepage (was previously pointed at 'dev version' page
- Removed nowrap formatting from supported languages list, was causing unnecessary rendering wonkyness in narrow browser windows
