### PR TITLE
Fix issue #88 - Culdn't determine language

### DIFF
--- a/SublimeCodeIntel.py
+++ b/SublimeCodeIntel.py
@@ -231,8 +231,8 @@ def guess_lang(view=None, path=None):
 
     mgr = codeintel_manager()
 
-    _codeintel_disabled_languages = [l.lower() for l in view.settings().get('codeintel_disabled_languages', [])]
-    if lang and lang.lower() in _codeintel_disabled_languages:
+    _codeintel_disabled_languages = [unicode(l.lower()) for l in view.settings().get('codeintel_disabled_languages', [])]
+    if lang and unicode(lang.lower()) in _codeintel_disabled_languages:
         logger(view, 'info', "skip `%s': disabled language" % lang)
         languages[id][_k_] = None
         return


### PR DESCRIPTION
I've fixed the annoying "Warning: skip 'PATH' couldn't determine language" message, it'd be nice if its merged to the upstream version so everyone can get the fix through Package Control.
