### PR TITLE
Escape spaces in your readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,11 +37,11 @@ The "Packages" packages directory is located at:
 
 * OS X::
 
-    ~/Library/Application Support/Sublime Text 2/Packages/
+    ~/Library/Application\ Support/Sublime\ Text\ 2/Packages/
 
 * Linux::
 
-    ~/.Sublime Text 2/Packages/
+    ~/.Sublime\ Text\ 2/Packages/
 
 * Windows::
 


### PR DESCRIPTION
Your example paths in the readme don't have escaped spaces and it took me a minute to figure out why they didn't work.
