### PR TITLE
Fix sorting

### DIFF
--- a/SublimeCodeIntel.py
+++ b/SublimeCodeIntel.py
@@ -296,7 +296,7 @@ def autocomplete(view, timeout, busy_timeout, preemptive=False, args=[], kwargs=
                     # Show autocompletions:
                     _completions = sorted(
                         [('%s  (%s)' % (name, type), name + ('(${1})' if type == 'function' else '')) for type, name in cplns],
-                        cmp=lambda a, b: a[1] < b[1] if a[1].startswith('_') and b[1].startswith('_') else False if a[1].startswith('_') else True if b[1].startswith('_') else a[1] < b[1]
+                        cmp=lambda a, b: cmp(a[1], b[1]) if a[1].startswith('_') == b[1].startswith('_') else 1 if a[1].startswith('_') else -1
                     )
                     if _completions:
                         completions[id] = _completions


### PR DESCRIPTION
Commit 22625a33a2167cf76563588a963ec6e0aabe81a3 apparently intended to change the sort order so that autocompletion matches that begin with "_" always appear at the end of the list of suggestions; but it was done incorrectly. The comparison function that is passed to Python's `sorted()` function expects a return value of -1/0/1, not True/False.
