### PR TITLE
Added limited support for Method::Signatures to Perl parser

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>SublimeCodeIntel</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.python.pydev.PyDevBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.python.pydev.pythonNature</nature>
+	</natures>
+</projectDescription>

--- a/.pydevproject
+++ b/.pydevproject
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?eclipse-pydev version="1.0"?><pydev_project>
+<pydev_pathproperty name="org.python.pydev.PROJECT_SOURCE_PATH">
+<path>/SublimeCodeIntel/libs</path>
+</pydev_pathproperty>
+<pydev_property name="org.python.pydev.PYTHON_PROJECT_VERSION">python 2.7</pydev_property>
+<pydev_property name="org.python.pydev.PYTHON_PROJECT_INTERPRETER">Default</pydev_property>
+</pydev_project>

--- a/SublimeCodeIntel.py
+++ b/SublimeCodeIntel.py
@@ -311,7 +311,7 @@ def autocomplete(view, timeout, busy_timeout, preemptive=False, args=[], kwargs=
                     calltip(view, 'tip', calltips[0])
 
                     if content[sel.a - 1] == '(' and content[sel.a] == ')':
-                        rex = re.compile("\(([^\[\(\)]*)")
+                        rex = re.compile( "\((.*?)\)" )
                         m = rex.search(calltips[0])
 
                         if m is None:

--- a/libs/SilverCity/Keywords.py
+++ b/libs/SilverCity/Keywords.py
@@ -60,7 +60,7 @@ perl_keywords = \
     "system syswrite tell telldir tie tied time times tr truncate "\
     "uc ucfirst umask undef unless unlink unpack unshift untie until "\
     "use utime values vec wait waitpid wantarray warn when while write "\
-    "x xor y"
+    "x xor y func method"
 
 python_keywords = \
     "and assert break class continue def del elif else except " \

--- a/libs/SilverCity/Keywords.py
+++ b/libs/SilverCity/Keywords.py
@@ -45,7 +45,7 @@ perl_keywords = \
     "getpgrp getppid getpriority getprotobyname getprotobynumber getprotoent "\
     "getpwent getpwnam getpwuid getservbyname getservbyport getservent "\
     "getsockname getsockopt given glob gmtime goto grep gt hex if import "\
-    "include index "\
+    "include index func method "\
     "int ioctl join keys kill last lc lcfirst le length link listen "\
     "local localtime lock log lstat lt m map mkdir msgctl msgget msgrcv "\
     "msgsnd my ne new next no not oct open opendir or ord our pack package "\

--- a/libs/ciElementTree.py
+++ b/libs/ciElementTree.py
@@ -23,3 +23,5 @@ except ImportError:
                         platform = "MacOS X Universal"
                     except ImportError:
                         raise ImportError("Could not find a suitable ciElementTree binary for your platform and architecture.")
+
+from xml.etree.ElementTree import tostring

--- a/libs/codeintel2/lang_perl.py
+++ b/libs/codeintel2/lang_perl.py
@@ -55,6 +55,7 @@ from SilverCity.Lexer import Lexer
 from SilverCity import ScintillaConstants
 
 from codeintel2.common import *
+from codeintel2.common import _xpcom_
 from codeintel2.citadel import (ImportHandler, CitadelBuffer,
                                 CitadelEvaluator, CitadelLangIntel)
 from codeintel2.citadel_common import ScanRequest
@@ -69,7 +70,7 @@ from codeintel2.langintel import (ParenStyleCalltipIntelMixin,
                                   ProgLangTriggerIntelMixin)
 
 if _xpcom_:
-    from xpcom.server import UnwrapObject
+    from xpcom.server import UnwrapObject  # @UnresolvedImport
 
 
 

--- a/libs/codeintel2/lang_perl.py
+++ b/libs/codeintel2/lang_perl.py
@@ -410,7 +410,7 @@ class PerlLangIntel(CitadelLangIntel,
     #[[[end]]]
 
     # Match a subroutine definition. Used by trg_from_pos()
-    _sub_pat = re.compile(r"\bsub\s+(\w+(::|'))*\w+$")
+    _sub_pat = re.compile( r"\b(?:sub|func|method)\s+(\w+(::|'))*\w+$" )
     # All Perl trigger points occur at one of these characters:
     #   ' ' (space)         only supported for built-in functions
     #   '(' (open paren)
@@ -605,7 +605,7 @@ class PerlLangIntel(CitadelLangIntel,
                     print "no: calltip trigger on Perl var not supported"
                 return None
             if identifier in ("if", "else", "elsif", "while", "for",
-                              "sub", "unless", "my", "our"):
+                              "sub", "func", "method", "unless", "my", "our" ):
                 if DEBUG:
                     print "no: no trigger on anonymous sub or control structure"
                 return None
@@ -618,7 +618,7 @@ class PerlLangIntel(CitadelLangIntel,
             line = text[:end].splitlines(0)[-1]
             if DEBUG:
                 print "  trigger line: %r" % line
-            if "sub " in line: # only use regex if "sub " on that line
+            if "sub " in line or "func " in line or "method ":  # only use regex if "sub " on that line
                 if DEBUG:
                     print "  *could* be a subroutine definition"
                 if self._sub_pat.search(line):

--- a/libs/codeintel2/lang_perl.py
+++ b/libs/codeintel2/lang_perl.py
@@ -410,7 +410,7 @@ class PerlLangIntel(CitadelLangIntel,
     #[[[end]]]
 
     # Match a subroutine definition. Used by trg_from_pos()
-    _sub_pat = re.compile(r"\bsub\s+(\w+(::|'))*\w+$")
+    _sub_pat = re.compile(r"\b(?:sub|func|method)\s+(\w+(::|'))*\w+")
     # All Perl trigger points occur at one of these characters:
     #   ' ' (space)         only supported for built-in functions
     #   '(' (open paren)
@@ -605,7 +605,7 @@ class PerlLangIntel(CitadelLangIntel,
                     print "no: calltip trigger on Perl var not supported"
                 return None
             if identifier in ("if", "else", "elsif", "while", "for",
-                              "sub", "unless", "my", "our"):
+                              "sub", "func", "method", "unless", "my", "our", "state"):
                 if DEBUG:
                     print "no: no trigger on anonymous sub or control structure"
                 return None
@@ -618,7 +618,7 @@ class PerlLangIntel(CitadelLangIntel,
             line = text[:end].splitlines(0)[-1]
             if DEBUG:
                 print "  trigger line: %r" % line
-            if "sub " in line: # only use regex if "sub " on that line
+            if "sub " in line or "func " in line or "method " in line: # only use regex if "sub " on that line
                 if DEBUG:
                     print "  *could* be a subroutine definition"
                 if self._sub_pat.search(line):

--- a/libs/codeintel2/lexers/Perl2.lexres
+++ b/libs/codeintel2/lexers/Perl2.lexres
@@ -54,7 +54,7 @@
 12:and stat study sub substr symlink syscall sysopen sysread sysseek system sy
 12:swrite tell telldir tie tied time times tr truncate uc ucfirst umask undef 
 12:unless unlink unpack unshift untie until use utime values vec wait waitpid 
-12:wantarray warn while write xor y
+12:wantarray warn while write xor y method func
 21
 22:45:44
 23

--- a/libs/codeintel2/perl_lexer.py
+++ b/libs/codeintel2/perl_lexer.py
@@ -227,6 +227,8 @@ def provide_sample_code():
  # comment at col 1
   # comment at col 2
 
+my $a = Foo->new();
+
 {
 package Foo;
 
@@ -234,6 +236,18 @@ sub new {
    my ($class, %args) = @_;
    my $self = {count => 0, list = [] };
    bless $self, (ref $class || $class);
+}
+
+func f_m  ($self, $arg) {
+    push @{$self->{list}}, $arg;
+    $self->{count} += 1;
+    $arg;
+}
+
+method m_m ($arg) {
+    push @{$self->{list}}, $arg;
+    $self->{count} += 1;
+    $arg;
 }
 
 sub m {
@@ -265,8 +279,8 @@ sub our_generate { my $self = shift; my $file_info = shift;
        print qq(percent string\n);
     }
 
-   }
-   }
+}
+}
 """
 
 

--- a/libs/codeintel2/perl_lexer.py
+++ b/libs/codeintel2/perl_lexer.py
@@ -267,8 +267,11 @@ sub our_generate { my $self = shift; my $file_info = shift;
 
    }
    }
-"""
 
+func test_func( $var1, $var2, $var4) {
+    return join ', ', ($var1, $var2, $var4);
+}
+"""
 
 if __name__ == "__main__":
     shared_lexer.main(sys.argv, provide_sample_code, PerlLexer)

--- a/libs/codeintel2/perl_parser.py
+++ b/libs/codeintel2/perl_parser.py
@@ -1,25 +1,25 @@
 # ***** BEGIN LICENSE BLOCK *****
 # Version: MPL 1.1/GPL 2.0/LGPL 2.1
-# 
+#
 # The contents of this file are subject to the Mozilla Public License
 # Version 1.1 (the "License"); you may not use this file except in
 # compliance with the License. You may obtain a copy of the License at
 # http://www.mozilla.org/MPL/
-# 
+#
 # Software distributed under the License is distributed on an "AS IS"
 # basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
 # License for the specific language governing rights and limitations
 # under the License.
-# 
+#
 # The Original Code is Komodo code.
-# 
+#
 # The Initial Developer of the Original Code is ActiveState Software Inc.
 # Portions created by ActiveState Software Inc are Copyright (C) 2000-2007
 # ActiveState Software Inc. All Rights Reserved.
-# 
+#
 # Contributor(s):
 #   ActiveState Software Inc
-# 
+#
 # Alternatively, the contents of this file may be used under the terms of
 # either the GNU General Public License Version 2 or later (the "GPL"), or
 # the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
@@ -31,7 +31,7 @@
 # and other provisions required by the GPL or the LGPL. If you do not delete
 # the provisions above, a recipient may use your version of this file under
 # the terms of any one of the MPL, the GPL or the LGPL.
-# 
+#
 # ***** END LICENSE BLOCK *****
 #
 # Contributors:
@@ -51,7 +51,7 @@ import logging
 
 from ciElementTree import Element, SubElement, tostring
 from SilverCity import ScintillaConstants
-from SilverCity.ScintillaConstants import (
+from SilverCity.ScintillaConstants import ( 
     SCE_PL_DEFAULT, SCE_PL_ERROR, SCE_PL_COMMENTLINE, SCE_PL_POD,
     SCE_PL_NUMBER, SCE_PL_WORD, SCE_PL_STRING, SCE_PL_CHARACTER,
     SCE_PL_PUNCTUATION, SCE_PL_PREPROCESSOR, SCE_PL_OPERATOR,
@@ -62,7 +62,7 @@ from SilverCity.ScintillaConstants import (
     SCE_PL_STRING_Q, SCE_PL_STRING_QQ, SCE_PL_STRING_QX, SCE_PL_STRING_QR,
     SCE_PL_STRING_QW, SCE_PL_POD_VERB, SCE_PL_SUB, SCE_PL_SUB_ARGS,
     SCE_PL_UNKNOWN_FIELD, SCE_PL_STDIN, SCE_PL_STDOUT, SCE_PL_STDERR,
-    SCE_PL_FORMAT, SCE_PL_UPPER_BOUND)
+    SCE_PL_FORMAT, SCE_PL_UPPER_BOUND )
 
 from codeintel2.common import CILEError
 from codeintel2 import perl_lexer
@@ -71,65 +71,65 @@ from codeintel2 import shared_parser
 
 SCE_PL_UNUSED = shared_lexer.EOF_STYLE
 
-log = logging.getLogger("perlcile")
+log = logging.getLogger( "perlcile" )
 #log.setLevel(logging.DEBUG)
 
 #----  memoize from http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/496879
 
-TIMING = False # set to true to capture timing data from regexen
-REGEXEN = {} # unused if TIMING is not True
+TIMING = False  # set to true to capture timing data from regexen
+REGEXEN = {}  # unused if TIMING is not True
 
-def memoize(function, limit=None):
-    if isinstance(function, int):
-        def memoize_wrapper(f):
-            return memoize(f, function)
+def memoize( function, limit = None ):
+    if isinstance( function, int ):
+        def memoize_wrapper( f ):
+            return memoize( f, function )
 
         return memoize_wrapper
+    else:
+        dict = {}
+        list = []
+        def memoize_wrapper( *args, **kwargs ):
+            key = cPickle.dumps( ( args, kwargs ) )
+            try:
+                list.append( list.pop( list.index( key ) ) )
+            except ValueError:
+                dict[key] = function( *args, **kwargs )
+                list.append( key )
+                if limit is not None and len( list ) > limit:
+                    del dict[list.pop( 0 )]
 
-    dict = {}
-    list = []
-    def memoize_wrapper(*args, **kwargs):
-        key = cPickle.dumps((args, kwargs))
-        try:
-            list.append(list.pop(list.index(key)))
-        except ValueError:
-            dict[key] = function(*args, **kwargs)
-            list.append(key)
-            if limit is not None and len(list) > limit:
-                del dict[list.pop(0)]
+            return dict[key]
 
-        return dict[key]
-
-    memoize_wrapper._memoize_dict = dict
-    memoize_wrapper._memoize_list = list
-    memoize_wrapper._memoize_limit = limit
-    memoize_wrapper._memoize_origfunc = function
-    memoize_wrapper.func_name = function.func_name
-    return memoize_wrapper
+        memoize_wrapper._memoize_dict = dict
+        memoize_wrapper._memoize_list = list
+        memoize_wrapper._memoize_limit = limit
+        memoize_wrapper._memoize_origfunc = function
+        memoize_wrapper.func_name = function.func_name
+        return memoize_wrapper
 
 
 class TimingRe:
     "A wrapper around compiled regexen that keeps track of timing data"
-    def __init__(self, re, orig_re):
+    def __init__( self, re, orig_re ):
         self._re = re
         self._orig_re = orig_re
-    def sub(self, *args):
-        return self._timing_operation('sub', *args)
-    def match(self, *args):
-        return self._timing_operation('match', *args)
-    def search(self, *args):
-        return self._timing_operation('search', *args)
-    def split(self, *args):
-        return self._timing_operation('split', *args)
-    def findall(self, *args):
-        return self._timing_operation('findall', *args)
+    def sub( self, *args ):
+        return self._timing_operation( 'sub', *args )
+    def match( self, *args ):
+        return self._timing_operation( 'match', *args )
+    def search( self, *args ):
+        return self._timing_operation( 'search', *args )
+    def split( self, *args ):
+        return self._timing_operation( 'split', *args )
+    def findall( self, *args ):
+        return self._timing_operation( 'findall', *args )
 
-    def _timing_operation(self, methodname, *args):
+    def _timing_operation( self, methodname, *args ):
         start = time.time()
-        retval = getattr(self._re, methodname)(*args)
+        retval = getattr( self._re, methodname )( *args )
         end = time.time()
-        delta = end-start
-        #if delta > 0.01:
+        delta = end - start
+        # if delta > 0.01:
         #    print delta,'\t', self._orig_re, str(args)[:80]
         if self._orig_re not in REGEXEN:
             REGEXEN[self._orig_re] = 0.0
@@ -137,105 +137,105 @@ class TimingRe:
         return retval
 
 @memoize
-def re_compile(regex, *args):
+def re_compile( regex, *args ):
     """A version of re.compile which memoizes and optionally keeps track of timing
     data"""
     if TIMING:
-        return TimingRe(re.compile(regex, *args), regex)
+        return TimingRe( re.compile( regex, *args ), regex )
     else:
-        return re.compile(regex, *args)
+        return re.compile( regex, *args )
 
-def re_sub(*args):
+def re_sub( *args ):
     """a version of re.sub which deals with TimingRe objects and prints out
     details of slow regexen"""
     if TIMING:
         start = time.time()
-        if isinstance(args[0], TimingRe):
-            retval = args[0].sub(*args[1:])
+        if isinstance( args[0], TimingRe ):
+            retval = args[0].sub( *args[1:] )
         else:
-            retval = re.sub(*args)
+            retval = re.sub( *args )
         end = time.time()
-        delta = end-start
-        if delta > 0.01: #adjust as needed.
-            print delta,'\t',args
+        delta = end - start
+        if delta > 0.01:  # adjust as needed.
+            print delta, '\t', args
     else:
-        retval = re.sub(*args)
+        retval = re.sub( *args )
     return retval
 
 class PerlCommonClassifier:
     """Mixin class containing classifier callbacks"""
 
-    def is_array_cb(self, tok):
+    def is_array_cb( self, tok ):
         tval = tok.text
-        return len(tval) >= 2 and tval[0] == '@' and tval[1] != '$'
+        return len( tval ) >= 2 and tval[0] == '@' and tval[1] != '$'
         # @$name is more like an expression -- don't return it
 
-    def is_scalar_cb(self, tok):
+    def is_scalar_cb( self, tok ):
         tval = tok.text
-        return len(tval) > 1 and tval[0] == '$' and (tval[1].isalnum or tval[1] == "_")
+        return len( tval ) > 1 and tval[0] == '$' and ( tval[1].isalnum or tval[1] == "_" )
 
-    def is_pod_cb(self, tok):
-        return tok.text[0] == '=' and tok.text[1].isalnum and tok.text.find("\n=cut", 5) > 0
-    
-    def is_string_qw_cb(self, tok):
-        return re_compile(r'^qw\s*[^\w\d_]').match(tok.text)
-                                                   
+    def is_pod_cb( self, tok ):
+        return tok.text[0] == '=' and tok.text[1].isalnum and tok.text.find( "\n=cut", 5 ) > 0
+
+    def is_string_qw_cb( self, tok ):
+        return re_compile( r'^qw\s*[^\w\d_]' ).match( tok.text )
+
 
     # Used for stripping the quotes off a string
-    _quote_patterns = {SCE_PL_STRING : re.compile('^[\'\"](.*)[\'\"]$'),
-                       SCE_PL_CHARACTER : re.compile('^\'(.*)\'$'),
-                       SCE_PL_STRING_Q : re.compile(r'^q\s*.(.*).$'),
-                       SCE_PL_STRING_QQ : re.compile(r'^q\w\s*.(.*).$'),
-                       SCE_PL_DEFAULT : re.compile('^.(.*).$'), #fallback
+    _quote_patterns = {SCE_PL_STRING : re.compile( '^[\'\"](.*)[\'\"]$' ),
+                       SCE_PL_CHARACTER : re.compile( '^\'(.*)\'$' ),
+                       SCE_PL_STRING_Q : re.compile( r'^q\s*.(.*).$' ),
+                       SCE_PL_STRING_QQ : re.compile( r'^q\w\s*.(.*).$' ),
+                       SCE_PL_DEFAULT : re.compile( '^.(.*).$' ),  # fallback
                        }
 
-    def quote_patterns_cb(self, tok):
+    def quote_patterns_cb( self, tok ):
         # Caller wants an array.
-        return [self.quote_patterns_cb_aux(tok)]
+        return [self.quote_patterns_cb_aux( tok )]
 
-    def quote_patterns_cb_aux(self, tok):
+    def quote_patterns_cb_aux( self, tok ):
         tval = tok.text
         if tval[0] == '"':
             return self._quote_patterns[SCE_PL_STRING]
         elif tval[0] == '\'':
             return self._quote_patterns[SCE_PL_CHARACTER]
-        elif tval.startswith("Q"):
+        elif tval.startswith( "Q" ):
             return self._quote_patterns[SCE_PL_STRING_QQ]
-        elif tval.startswith("q"):
+        elif tval.startswith( "q" ):
             return self._quote_patterns[SCE_PL_STRING_Q]
         else:
-            return self._quote_patterns[SCE_PL_DEFAULT] # Fallback
+            return self._quote_patterns[SCE_PL_DEFAULT]  # Fallback
 
-class UDLClassifier(PerlCommonClassifier, shared_parser.UDLClassifier):
+class UDLClassifier( PerlCommonClassifier, shared_parser.UDLClassifier ):
     pass
 
-class PerlClassifier(PerlCommonClassifier, shared_parser.CommonClassifier):
-    def get_builtin_type(self, tok, callback):
-        raise CILEError("Unexpected call to perl_parser.get_builtin_type")
-        
-    def is_any_operator(self, tok):
+class PerlClassifier( PerlCommonClassifier, shared_parser.CommonClassifier ):
+    def get_builtin_type( self, tok, callback ):
+        raise CILEError( "Unexpected call to perl_parser.get_builtin_type" )
+
+    def is_any_operator( self, tok ):
         return tok.style == ScintillaConstants.SCE_PL_OPERATOR
 
-    def is_comment(self, tok):
-        return tok.style in (ScintillaConstants.SCE_PL_COMMENT,
-                             ScintillaConstants.SCE_PL_POD)
+    def is_comment( self, tok ):
+        return tok.style in ( ScintillaConstants.SCE_PL_COMMENTLINE,
+                             ScintillaConstants.SCE_PL_POD )
 
-    def is_comment_structured(self, tok, callback):
+    def is_comment_structured( self, tok, callback ):
         return tok.style == ScintillaConstants.SCE_PL_POD
 
-    def is_identifier(self, tok, allow_keywords=False):
-        return (tok.style == ScintillaConstants.SCE_PL_IDENTIFIER or
-            (allow_keywords and
-             tok.style == ScintillaConstants.SCE_PL_WORD))
+    def is_identifier( self, tok, allow_keywords = False ):
+        return ( tok.style == ScintillaConstants.SCE_PL_IDENTIFIER or
+            ( allow_keywords and
+             tok.style == ScintillaConstants.SCE_PL_WORD ) )
 
-    def is_index_op(self, tok, pattern=None):
-        if not (tok.style in (SCE_PL_OPERATOR, SCE_PL_VARIABLE_INDEXER)):
+    def is_index_op( self, tok, pattern = None ):
+        if not ( tok.style in ( SCE_PL_OPERATOR, SCE_PL_VARIABLE_INDEXER ) ):
             return False
         elif not pattern:
             return True
-        return len(tok.text) > 0 and pattern.search(tok.text)
+        return len( tok.text ) > 0 and pattern.search( tok.text )
 
-    def is_interpolating_string(self, tok, callback):
+    def is_interpolating_string( self, tok, callback ):
         return tok.style in [ScintillaConstants.SCE_PL_STRING,
                              ScintillaConstants.SCE_PL_REGEX,
                              ScintillaConstants.SCE_PL_HERE_QQ,
@@ -244,16 +244,16 @@ class PerlClassifier(PerlCommonClassifier, shared_parser.CommonClassifier):
                              ScintillaConstants.SCE_PL_STRING_QX
                              ]
 
-    def is_keyword(self, tok, target):
+    def is_keyword( self, tok, target ):
         return tok.style == ScintillaConstants.SCE_PL_WORD and tok.text == target
 
-    def is_number(self, tok):
+    def is_number( self, tok ):
         return tok.style == ScintillaConstants.SCE_PL_NUMBER
 
-    def is_operator(self, tok, target):
+    def is_operator( self, tok, target ):
         return tok.style == ScintillaConstants.SCE_PL_OPERATOR and tok.text == target
 
-    def is_string(self, tok):
+    def is_string( self, tok ):
         return tok.style in [ScintillaConstants.SCE_PL_STRING,
                              ScintillaConstants.SCE_PL_CHARACTER,
                              ScintillaConstants.SCE_PL_HERE_Q,
@@ -263,35 +263,35 @@ class PerlClassifier(PerlCommonClassifier, shared_parser.CommonClassifier):
                              ScintillaConstants.SCE_PL_STRING_QX,
                              ]
 
-    def is_string_qw(self, tok, callback):
+    def is_string_qw( self, tok, callback ):
         return tok.style == ScintillaConstants.SCE_PL_STRING_QW
 
-    def is_symbol(self, tok):
+    def is_symbol( self, tok ):
         return False
 
-    def is_variable(self, tok):
+    def is_variable( self, tok ):
         return SCE_PL_SCALAR <= tok.style <= SCE_PL_SYMBOLTABLE
 
     # Types of variables
-    def is_variable_array(self, tok, callback=None):
+    def is_variable_array( self, tok, callback = None ):
         return tok.style == ScintillaConstants.SCE_PL_ARRAY and \
-            len(tok.text) > 1 and tok.text[1] != '$'
-        
-    def is_variable_scalar(self, tok, callback=None):
+            len( tok.text ) > 1 and tok.text[1] != '$'
+
+    def is_variable_scalar( self, tok, callback = None ):
         return tok.style == ScintillaConstants.SCE_PL_SCALAR and \
-            len(tok.text) > 1 and tok.text[1] != '$'
-        
+            len( tok.text ) > 1 and tok.text[1] != '$'
+
     # Accessors for where we'd rather work with a style than call a predicate fn
 
     @property
-    def style_identifier(self):
+    def style_identifier( self ):
         return ScintillaConstants.SCE_PL_IDENTIFIER
-    
+
     @property
-    def style_word(self):
+    def style_word( self ):
         return ScintillaConstants.SCE_PL_WORD
 
-def _get_classifier(lang):
+def _get_classifier( lang ):
     """Factory method for choosing the style classifier."""
     cls = lang == "Perl" and PerlClassifier or UDLClassifier
     return cls()
@@ -301,7 +301,7 @@ def _get_classifier(lang):
 showWarnings = False
 
 class ModuleInfo:
-    def __init__(self, provide_full_docs):
+    def __init__( self, provide_full_docs ):
         self.provide_full_docs = provide_full_docs
 
         self.modules = {}
@@ -321,118 +321,118 @@ class ModuleInfo:
         self.local_string = '__local__'
         # Cached regular expressions
         self.re_bl = r'\r?\n\s*\r?\n'
-        self.tryGettingDoc_Sig_re3 = re_compile(r'^=(?:item|head)\w*\s*((?:(?!\n=).)*)(?!\n=)',
-                                 re.M|re.S)
-        self.printDocInfo_re4 = re_compile(r'^=(?:item|head)\w*\s*((?:(?!\n=).)*)(?!\n=)', re.S|re.M)
-        
-        self.printDocInfo_re2 = re_compile(r'^=\w+\s+DESCRIPTION%s(.*?)(?:%s|^=)' % (self.re_bl, self.re_bl), re.M)
-        self.printDocInfo_re6 = re_compile(r'^=\w+\s+SYNOPSIS' + self.re_bl + '(.*?)^=',
-                                           re.M|re.S)
-        self.printDocInfo_bdot_re = re_compile(r'\.\s+[A-Z].*\Z')
+        self.tryGettingDoc_Sig_re3 = re_compile( r'^=(?:item|head)\w*\s*((?:(?!\n=).)*)(?!\n=)',
+                                 re.M | re.S )
+        self.printDocInfo_re4 = re_compile( r'^=(?:item|head)\w*\s*((?:(?!\n=).)*)(?!\n=)', re.S | re.M )
 
-        self._get_first_sentence_re1 = re_compile(r'\.\s+[A-Z].*\Z', re.S)
+        self.printDocInfo_re2 = re_compile( r'^=\w+\s+DESCRIPTION%s(.*?)(?:%s|^=)' % ( self.re_bl, self.re_bl ), re.M )
+        self.printDocInfo_re6 = re_compile( r'^=\w+\s+SYNOPSIS' + self.re_bl + '(.*?)^=',
+                                           re.M | re.S )
+        self.printDocInfo_bdot_re = re_compile( r'\.\s+[A-Z].*\Z' )
 
-        self._simple_depod_e_re = re_compile(r'E<(.*?)>', re.S)
-        self._simple_depod_c_re = re_compile(r'C<{2,}\s*(.*?)\s*>{2,}', re.S)
-        self._simple_depod_ibcfsxl_re1 = re_compile(r'[IBCFSXL]<[^>\n]*>')
-        self._simple_depod_ibcfsxl_re2 = re_compile(r'[IBCFSX]<(<*[^<>]*?>*)>', re.S)
-        self._simple_depod_l_re = re_compile(r'L<\/?(.*?)>')
-        self._simple_depod_rest_re = re_compile(r'\w<\/?(<*.*?>*)>')
+        self._get_first_sentence_re1 = re_compile( r'\.\s+[A-Z].*\Z', re.S )
 
-        self._depod_re1 = re_compile(r'^=begin\s+man\s+.*?^=end\s+man\s*', re.M|re.S)
-        self._depod_re2 = re_compile(r'^=\w+\s*', re.M)
-        self._depod_re3 = re_compile(r'\]\]>')
-        self._depod_re4 = re_compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+        self._simple_depod_e_re = re_compile( r'E<(.*?)>', re.S )
+        self._simple_depod_c_re = re_compile( r'C<{2,}\s*(.*?)\s*>{2,}', re.S )
+        self._simple_depod_ibcfsxl_re1 = re_compile( r'[IBCFSXL]<[^>\n]*>' )
+        self._simple_depod_ibcfsxl_re2 = re_compile( r'[IBCFSX]<(<*[^<>]*?>*)>', re.S )
+        self._simple_depod_l_re = re_compile( r'L<\/?(.*?)>' )
+        self._simple_depod_rest_re = re_compile( r'\w<\/?(<*.*?>*)>' )
 
-        self.trim_ws_re1 = re_compile(r'(?<=\w[\.\!\?])\s+')
-        self.trim_ws_re2 = re_compile(r'[\r\n\t]')
-        self.trim_ws_re3 = re_compile(r' {2,}')
+        self._depod_re1 = re_compile( r'^=begin\s+man\s+.*?^=end\s+man\s*', re.M | re.S )
+        self._depod_re2 = re_compile( r'^=\w+\s*', re.M )
+        self._depod_re3 = re_compile( r'\]\]>' )
+        self._depod_re4 = re_compile( r'[\x00-\x08\x0b\x0c\x0e-\x1f]' )
 
-        self.printFunctions_re1 = re_compile(r'(\S)\s*\n(?:\s*\n)*\s*(\S)')
-    
-    def doStartNS(self, ns):
+        self.trim_ws_re1 = re_compile( r'(?<=\w[\.\!\?])\s+' )
+        self.trim_ws_re2 = re_compile( r'[\r\n\t]' )
+        self.trim_ws_re3 = re_compile( r' {2,}' )
+
+        self.printFunctions_re1 = re_compile( r'(\S)\s*\n(?:\s*\n)*\s*(\S)' )
+
+    def doStartNS( self, ns ):
         name = ns.name
-        if not self.modules.has_key(name):
+        if not self.modules.has_key( name ):
             self.modules[name] = ns
         self.currentNS = ns
-        
-    def doEndNS(self, **attrInfo):
-        if attrInfo.has_key('lineNo'):
+
+    def doEndNS( self, **attrInfo ):
+        if attrInfo.has_key( 'lineNo' ):
             self.currentNS.lineend = attrInfo['lineNo']
         self.currentNS = None
-        
-    def getNS(self, name, **attrInfo):
-        if self.modules.has_key(name):
+
+    def getNS( self, name, **attrInfo ):
+        if self.modules.has_key( name ):
             return self.modules[name]
         else:
-            return NamespaceInfo(name, **attrInfo)
-        
-    def doSetArg(self, name):
+            return NamespaceInfo( name, **attrInfo )
+
+    def doSetArg( self, name ):
         self.currentFunction.aArg[name] = []
-        self.currentFunction.argList.append(name)
-        
-    def doSetParent(self, **attrInfo):
-        ns = attrInfo.get('ns')
+        self.currentFunction.argList.append( name )
+
+    def doSetParent( self, **attrInfo ):
+        ns = attrInfo.get( 'ns' )
         if ns:
-            self.currentNS.aParent.append(ns)
-            
-    def doStartFn(self, fn):
+            self.currentNS.aParent.append( ns )
+
+    def doStartFn( self, fn ):
         self.currentFunction = fn
-        
-    def doEndFn(self, **attrInfo):
-        if attrInfo.has_key('lineNo'):
-            self.currentFunction.lineend = attrInfo.get('lineNo')
-        self.currentNS.aFunc.append(self.currentFunction)
+
+    def doEndFn( self, **attrInfo ):
+        if attrInfo.has_key( 'lineNo' ):
+            self.currentFunction.lineend = attrInfo.get( 'lineNo' )
+        self.currentNS.aFunc.append( self.currentFunction )
         self.currentFunction = None
-        
-    def doStartVar(self, **attrInfo):
+
+    def doStartVar( self, **attrInfo ):
         self.thisVar = {}
-        self.thisVar['name'] = attrInfo.get('name')
+        self.thisVar['name'] = attrInfo.get( 'name' )
         for field in ['line', 'aType', 'scope']:
-            if attrInfo.has_key(field):
+            if attrInfo.has_key( field ):
                 self.thisVar[field] = attrInfo[field]
-    
-    def doEndVar(self, forceGlobal):
+
+    def doEndVar( self, forceGlobal ):
         name = self.thisVar['name']
-        if (not forceGlobal) and self.currentFunction:
-            if self.currentFunction.aArg.has_key(name):
-                self.currentFunction.aArg[name].append(self.thisVar)
+        if ( not forceGlobal ) and self.currentFunction:
+            if self.currentFunction.aArg.has_key( name ):
+                self.currentFunction.aArg[name].append( self.thisVar )
             else:
-                self.set_or_append(self.currentFunction.aVar, name, self.thisVar)
+                self.set_or_append( self.currentFunction.aVar, name, self.thisVar )
         else:
-            self.set_or_append(self.currentNS.aVar, name, self.thisVar)
+            self.set_or_append( self.currentNS.aVar, name, self.thisVar )
         del self.thisVar
-        
-    def set_or_append(self, obj, name, val):
-        if obj.has_key(name):
-            obj[name].append(val)
+
+    def set_or_append( self, obj, name, val ):
+        if obj.has_key( name ):
+            obj[name].append( val )
         else:
             obj[name] = [val]
-            
-    def doSetVar(self, **args):
-        if args.has_key('forceGlobal'):
+
+    def doSetVar( self, **args ):
+        if args.has_key( 'forceGlobal' ):
             forceGlobal = args['forceGlobal']
             del args['forceGlobal']
         else:
             forceGlobal = False
-        self.doStartVar(**args)
-        self.doEndVar(forceGlobal)
+        self.doStartVar( **args )
+        self.doEndVar( forceGlobal )
 
-    def add_imported_module(self, args, **kwargs):
-        args2 = copy.copy(args)
-        args2.update(kwargs)
+    def add_imported_module( self, args, **kwargs ):
+        args2 = copy.copy( args )
+        args2.update( kwargs )
         if self.currentFunction:
-            self.currentFunction.aImports.append(args2)
+            self.currentFunction.aImports.append( args2 )
         else:
-            self.currentNS.aImports.append(args2)
-    
-    def printDocInfo(self, modInfo, funcInfo, currNode):
+            self.currentNS.aImports.append( args2 )
+
+    def printDocInfo( self, modInfo, funcInfo, currNode ):
         docs = modInfo.hDocs['modules']
         modName = modInfo.name
         # These REs need rebuilding each time, as their values change on each call.
-        printDocInfo_re1 = re_compile(r'^=\w+\s+NAME%s%s[\s-]+(.*?)(?:%s|^=)' %
-                                      (self.re_bl, modName, self.re_bl), re.M)
-            
+        printDocInfo_re1 = re_compile( r'^=\w+\s+NAME%s%s[\s-]+(.*?)(?:%s|^=)' %
+                                      ( self.re_bl, modName, self.re_bl ), re.M )
+
         try:
             mainDocs = self.modules['main'].hDocs['modules'] or []
         except:
@@ -446,23 +446,23 @@ class ModuleInfo:
             #
             # Otherwise, go with the first one.
             for doc in docs:
-                m1 = printDocInfo_re1.search(doc)
+                m1 = printDocInfo_re1.search( doc )
                 if m1:
-                    finalDoc = self.trim_ws(m1.group(1), True)
+                    finalDoc = self.trim_ws( m1.group( 1 ), True )
                     break
                 else:
-                    m2 = self.printDocInfo_re2.search(doc)
+                    m2 = self.printDocInfo_re2.search( doc )
                     if m2:
-                        finalDoc = self.trim_ws(m2.group(1), True)
+                        finalDoc = self.trim_ws( m2.group( 1 ), True )
                         break
             if finalDoc is None:
                 # Look only for a qualified name in the NAME section,
                 # but don't look at the DESCRIPTION part until we can
                 # select the main class in a module.
                 for doc in mainDocs:
-                    m1 = printDocInfo_re1.search(doc)
+                    m1 = printDocInfo_re1.search( doc )
                     if m1:
-                        finalDoc = self.trim_ws(m1.group(1), True)
+                        finalDoc = self.trim_ws( m1.group( 1 ), True )
                         break
         else:
             # First look for the function name in an item
@@ -471,18 +471,18 @@ class ModuleInfo:
             funcName = funcInfo.name
             # Allow for datasection-based POD\
             if docs:
-                re3_s = (r'''
+                re3_s = ( r'''
                                 ((?:^=(?:item|head)\w*\s*\r?\n(?:\s*\r?\n)*
                                 .*?(?:%s\s*::|%s\s*->|\$[\w_]+\s*->|[ \t]+)
                                 %s(?![\w\d_]).*\r?\n\s*\r?\n)+)
                                 # Now the description
                                 # Everything up to the an equal-sign (or end)
                                 ((?:\r?\n|.)*?)(?:^=|\Z)''' %
-                                (modName, modName, funcName))
-                printDocInfo_re3 = re_compile(re3_s, re.X|re.M)
+                                ( modName, modName, funcName ) )
+                printDocInfo_re3 = re_compile( re3_s, re.X | re.M )
                 for doc in docs:
                     # Speed up: do index before doing a reg
-                    if doc.find(funcName) == -1:
+                    if doc.find( funcName ) == -1:
                         continue
                     # Find a function definition in an item or head thing
                     # Very general-purpose, might pick up false-positives
@@ -490,13 +490,13 @@ class ModuleInfo:
                     # Look for one or more =item/head lines,
                     # separate by blank lines,
                     # followed by a paragraph description
-                    m1 = printDocInfo_re3.search(doc)
+                    m1 = printDocInfo_re3.search( doc )
                     if m1:
-                        part1 = m1.group(1)
-                        finalDoc = self.trim_ws(m1.group(2), True)
-                        part2 = [self.trim_ws(s, True) for s in self.printDocInfo_re4.findall(part1)]
-                        finalDoc = "\n\n".join(part2) + "\n\n" + finalDoc
-                        finalDoc = self._get_first_sentence(finalDoc)
+                        part1 = m1.group( 1 )
+                        finalDoc = self.trim_ws( m1.group( 2 ), True )
+                        part2 = [self.trim_ws( s, True ) for s in self.printDocInfo_re4.findall( part1 )]
+                        finalDoc = "\n\n".join( part2 ) + "\n\n" + finalDoc
+                        finalDoc = self._get_first_sentence( finalDoc )
                         break
             if not finalDoc:
                 # Look in the __END__ section
@@ -506,43 +506,43 @@ class ModuleInfo:
                            \b%s.*%s)+
                             # Now the description
                             # Everything up to the an equal-sign (or end)
-                            ((?:\r?\n|.)*?)(?=$|^=)''' % (funcName, self.re_bl)
-                printDocInfo_re1 = re_compile(re1_s, re.M|re.X)
+                            ((?:\r?\n|.)*?)(?=$|^=)''' % ( funcName, self.re_bl )
+                printDocInfo_re1 = re_compile( re1_s, re.M | re.X )
                 for doc in mainDocs:
-                    m1 = printDocInfo_re1.search(doc)
+                    m1 = printDocInfo_re1.search( doc )
                     if m1:
-                        before_period = self.printDocInfo_bdot_re.sub('.', m1.group(1))
-                        finalDoc = self.trim_ws(self._get_first_sentence(m1.group(1)), True)
+                        before_period = self.printDocInfo_bdot_re.sub( '.', m1.group( 1 ) )
+                        finalDoc = self.trim_ws( self._get_first_sentence( m1.group( 1 ) ), True )
                         break
             if not finalDoc:
                 # Try to find a synopsis entry
-                printDocInfo_re7 = re_compile(r'(.*(?:::|->|\b)%s\b.*)' % (funcName,))
+                printDocInfo_re7 = re_compile( r'(.*(?:::|->|\b)%s\b.*)' % ( funcName, ) )
                 for doc in docs + mainDocs:
-                    m1 = self.printDocInfo_re6.search(doc)
+                    m1 = self.printDocInfo_re6.search( doc )
                     if m1:
-                        synopsis = m1.group(1)
-                        m2 = printDocInfo_re7.search(synopsis)
+                        synopsis = m1.group( 1 )
+                        m2 = printDocInfo_re7.search( synopsis )
                         if m2:
-                            finalDoc = self.trim_ws(self._get_first_sentence(m2.group(1)))
+                            finalDoc = self.trim_ws( self._get_first_sentence( m2.group( 1 ) ) )
                             break
         if finalDoc:
-            self.printDocString(finalDoc, currNode)
-            
-    def _get_first_sentence(self, s1):
-        s2 = self._get_first_sentence_re1.sub('.', s1)
+            self.printDocString( finalDoc, currNode )
+
+    def _get_first_sentence( self, s1 ):
+        s2 = self._get_first_sentence_re1.sub( '.', s1 )
         return s2
-    
-    def printDocString(self, finalDoc, currNode):
-        finalDoc2 = self._depod(finalDoc)
+
+    def printDocString( self, finalDoc, currNode ):
+        finalDoc2 = self._depod( finalDoc )
         if finalDoc2:
-            currNode.set('doc', finalDoc2)
-        
-    def _process_e_pod(self, src):
-        val = self.pod_escape_seq.get(src.lower())
+            currNode.set( 'doc', finalDoc2 )
+
+    def _process_e_pod( self, src ):
+        val = self.pod_escape_seq.get( src.lower() )
         if val: return val
-        if re.search(r'^\d+$', src):
+        if re.search( r'^\d+$', src ):
             return '&#%s;' % src
-        m1 = re.search(r'^0[Xx]([0-9a-fA-F]+)$', src)
+        m1 = re.search( r'^0[Xx]([0-9a-fA-F]+)$', src )
         if m1:
             return '&#x%s;' % src
         else:
@@ -554,196 +554,196 @@ class ModuleInfo:
             #                  &eacute;
             # Not great, but it causes no breakage.
             return '&amp;%s' % src
-        
-    def _wrap_process_e_pod(self, m):
-        return self._process_e_pod(m.group(1))
-        
-    def _simple_depod(self, doc):
+
+    def _wrap_process_e_pod( self, m ):
+        return self._process_e_pod( m.group( 1 ) )
+
+    def _simple_depod( self, doc ):
         # Simple inline-markup removal (doesn't handle nested inlines)
         # In Perl, do this:
         # $doc =~ s/E<(.*?)>/_process_e_pod($1)/eg;
 
-        doc = re_sub(self._simple_depod_e_re, self._wrap_process_e_pod, doc)
+        doc = re_sub( self._simple_depod_e_re, self._wrap_process_e_pod, doc )
 
         # And handle the inline codes-- thse nest with E codes...
-        
-        doc = self._simple_depod_c_re.sub(r'\1', doc)
+
+        doc = self._simple_depod_c_re.sub( r'\1', doc )
 
         # Above code replaces this:
         # doc = re_sub(r'C<{2,}\s+(.*?)\s+>{2,}', r'\1', doc)
         # doc = XmlAttrEscape(doc) -- No longer needed with ElementTree
-            
+
         # Allow the other sequences to nest, and loop until there
         # aren't any left.
-        
+
         old_doc = doc
-        while self._simple_depod_ibcfsxl_re1.search(doc):
+        while self._simple_depod_ibcfsxl_re1.search( doc ):
             # Most formatting sequences wrap a single clump of code
-            doc = self._simple_depod_ibcfsxl_re2.sub(r'\1', doc)
+            doc = self._simple_depod_ibcfsxl_re2.sub( r'\1', doc )
             # Handling of links - this is more complicated.
-            doc = self._simple_depod_l_re.sub(r'\1', doc)
-    
+            doc = self._simple_depod_l_re.sub( r'\1', doc )
+
             # We need to make sure we pull out when nothing changes.
-            #XXX A log message would be useful here.
+            # XXX A log message would be useful here.
             if old_doc != doc:
                 old_doc = doc
             else:
                 break
         # Remove any unrecognized sequences
-        doc = self._simple_depod_rest_re.sub(r'\1', doc)
+        doc = self._simple_depod_rest_re.sub( r'\1', doc )
 
         # And shrink entities back into strings.
         # This is done because we can't convert constructs like
         # E<gt> into ">" directly, because they'll prevent
         # proper handling of outer C<...> in strings like 'C<if (a E<gt> b) { ...>'
-        doc = doc.replace("&lt;", "<").replace("&gt;", ">")
+        doc = doc.replace( "&lt;", "<" ).replace( "&gt;", ">" )
         return doc
 
 # Precondition: this text is emitted inside a cdata-section
 
-    def _depod(self, doc):
+    def _depod( self, doc ):
         # Remove embedded man directives
-        doc1 = self._depod_re1.sub('', doc)
-    
+        doc1 = self._depod_re1.sub( '', doc )
+
         # Pull out leading equal signs and the directives
-        doc2 = self._depod_re2.sub('', doc1)
-        doc3 = self._simple_depod(doc2)
+        doc2 = self._depod_re2.sub( '', doc1 )
+        doc3 = self._simple_depod( doc2 )
         # Handle strings that could cause the XML parser trouble
-        doc4 = self._depod_re3.sub(']<!>]>', doc3)
-        doc5 = self._depod_re4.sub('?', doc4)
+        doc4 = self._depod_re3.sub( ']<!>]>', doc3 )
+        doc5 = self._depod_re4.sub( '?', doc4 )
         return doc5
-        
-    def trim_ws(self, str1, truncate=False):
+
+    def trim_ws( self, str1, truncate = False ):
         # First split into sentences
         str2 = str1.strip()
         if truncate:
-            sentences = self.trim_ws_re1.split(str2)
+            sentences = self.trim_ws_re1.split( str2 )
             keep_sentences = []
             sum = 0
             # Keep sentences until we pass max_doclet_high_water_mark chars.
             for s in sentences:
-                thisLen = len(s)
+                thisLen = len( s )
                 if sum and sum + thisLen > self.max_doclet_high_water_mark:
                     break
-                s1 = self.trim_ws_re2.sub(' ', s)
-                s2 = self.trim_ws_re3.sub(' ', s1)
-                keep_sentences.append(s2)
+                s1 = self.trim_ws_re2.sub( ' ', s )
+                s2 = self.trim_ws_re3.sub( ' ', s1 )
+                keep_sentences.append( s2 )
                 sum += thisLen
                 if sum > self.max_doclet_high_water_mark:
                     break
-            str2 = "  ".join(keep_sentences)
-        
-        if str2.find("\n") >= 0 or len(str2) > self.textWrapper.width * 1.1:
-            str2 = "\n".join(self.textWrapper.wrap(str2))
+            str2 = "  ".join( keep_sentences )
+
+        if str2.find( "\n" ) >= 0 or len( str2 ) > self.textWrapper.width * 1.1:
+            str2 = "\n".join( self.textWrapper.wrap( str2 ) )
         return str2
 
-    def printClassParents(self, modInfo, currNode):
-        if not hasattr(modInfo, 'aParent'): return
+    def printClassParents( self, modInfo, currNode ):
+        if not hasattr( modInfo, 'aParent' ): return
         classrefs = [info[0] for info in modInfo.aParent]
-        if len(classrefs) > 0:
-            currNode.set('classrefs', " ".join(classrefs))
-            
-    def printImports(self, modInfo, currNode):
+        if len( classrefs ) > 0:
+            currNode.set( 'classrefs', " ".join( classrefs ) )
+
+    def printImports( self, modInfo, currNode ):
         # -- this will be correct only when there are deliberate conflicts
         # better to use object inheritance to choose methods dynamically.
-        #imports = getattr(modInfo, 'aImports', [])
-        #imports.reverse()
-        for _import in getattr(modInfo, 'aImports', []):
+        # imports = getattr(modInfo, 'aImports', [])
+        # imports.reverse()
+        for _import in getattr( modInfo, 'aImports', [] ):
             attrs = _import.keys()
-            importNode = SubElement(currNode, "import")
+            importNode = SubElement( currNode, "import" )
             for k in attrs:
-                importNode.set(k, str(_import[k]))
-            
-    def printTypeInfo(self, argInfo, currNode):
-        types={}
+                importNode.set( k, str( _import[k] ) )
+
+    def printTypeInfo( self, argInfo, currNode ):
+        types = {}
         for type_ in argInfo:
-            typeInfo = type_.get('aType')
+            typeInfo = type_.get( 'aType' )
             if not typeInfo:
                 continue
-            elif not typeInfo.has_key('assign'):
+            elif not typeInfo.has_key( 'assign' ):
                 continue
             tp = typeInfo['assign']
-            if types.has_key(tp):
+            if types.has_key( tp ):
                 continue
             types[tp] = None
-            currNode.set('citdl', tp)
-            
-    def printVariables(self, modInfo, currNode):
-        if not hasattr(modInfo, 'aVar'): return
-        def sorter1(a,b):
-            return (cmp(a[0]['line'], b[0]['line']) or
-                    cmp(a[0]['name'].lower(), b[0]['name'].lower()))
-                   
+            currNode.set( 'citdl', tp )
+
+    def printVariables( self, modInfo, currNode ):
+        if not hasattr( modInfo, 'aVar' ): return
+        def sorter1( a, b ):
+            return ( cmp( a[0]['line'], b[0]['line'] ) or
+                    cmp( a[0]['name'].lower(), b[0]['name'].lower() ) )
+
         variables = modInfo.aVar.values()
-        variables.sort(sorter1)
+        variables.sort( sorter1 )
         try:
             export_info = modInfo.export_info
         except:
-            if not hasattr(self, 'default_export_info'):
-                self.default_export_info = {'@EXPORT':{},'@EXPORT_OK':{}}
+            if not hasattr( self, 'default_export_info' ):
+                self.default_export_info = {'@EXPORT':{}, '@EXPORT_OK':{}}
             export_info = self.default_export_info
         for varInfo in variables:
             var_name = varInfo[0]['name']
-            varNode = SubElement(currNode, 'variable', line=str(varInfo[0]['line']),
-                                 name=var_name)
+            varNode = SubElement( currNode, 'variable', line = str( varInfo[0]['line'] ),
+                                 name = var_name )
             attr_parts = []
-            if export_info['@EXPORT'].has_key(var_name):
-                attr_parts.append(self.export_string)
-            if export_info['@EXPORT_OK'].has_key(var_name):
-                attr_parts.append(self.export_ok_string)
+            if export_info['@EXPORT'].has_key( var_name ):
+                attr_parts.append( self.export_string )
+            if export_info['@EXPORT_OK'].has_key( var_name ):
+                attr_parts.append( self.export_ok_string )
             try:
                 if varInfo[0]['scope'] == 'my':
-                    attr_parts.append(self.local_string)
+                    attr_parts.append( self.local_string )
             except:
                 pass
             if attr_parts:
-                varNode.set('attributes', ' '.join(attr_parts))
-            self.printTypeInfo(varInfo, varNode)
-    
-    def printFunctions(self, modInfo, currNode):
-        for funcInfo in getattr(modInfo, 'aFunc', []):
-            sig, docString = self.tryGettingDoc_Sig(modInfo, funcInfo)
+                varNode.set( 'attributes', ' '.join( attr_parts ) )
+            self.printTypeInfo( varInfo, varNode )
+
+    def printFunctions( self, modInfo, currNode ):
+        for funcInfo in getattr( modInfo, 'aFunc', [] ):
+            sig, docString = self.tryGettingDoc_Sig( modInfo, funcInfo )
             funcName = funcInfo.name
             if not sig:
-                sig = '%s(%s)' % (funcName, ', '.join(funcInfo.argList))
+                sig = '%s(%s)' % ( funcName, ', '.join( funcInfo.argList ) )
             else:
-                sig = self._simple_depod(sig.strip())
-                sig = self.printFunctions_re1.sub('\\1\n\\2', sig)
-            funcNode = SubElement(currNode, 'scope', ilk='function', name=funcName)
+                sig = self._simple_depod( sig.strip() )
+                sig = self.printFunctions_re1.sub( '\\1\n\\2', sig )
+            funcNode = SubElement( currNode, 'scope', ilk = 'function', name = funcName )
             for attr_name in ['line', 'lineend']:
-                ln = getattr(funcInfo, attr_name, None)
+                ln = getattr( funcInfo, attr_name, None )
                 if ln:
-                    funcNode.set(attr_name, str(ln))
-    
+                    funcNode.set( attr_name, str( ln ) )
+
             attr_parts = []
             if funcInfo.isConstructor:
-                attr_parts.append("__ctor__")
+                attr_parts.append( "__ctor__" )
             export_info = modInfo.export_info
             for tuple in [['@EXPORT', self.export_string],
                           ['@EXPORT_OK', self.export_ok_string]]:
-                if export_info[tuple[0]].has_key(funcName):
-                    attr_parts.append(tuple[1])
+                if export_info[tuple[0]].has_key( funcName ):
+                    attr_parts.append( tuple[1] )
             if attr_parts:
-                funcNode.set('attributes', ' '.join(attr_parts))
+                funcNode.set( 'attributes', ' '.join( attr_parts ) )
 
-            funcNode.set('signature', sig)
-            
+            funcNode.set( 'signature', sig )
+
             for argName in funcInfo.argList:
-                argInfo = funcInfo.aArg.get(argName)
+                argInfo = funcInfo.aArg.get( argName )
                 if argInfo:
-                    argNode = SubElement(funcNode, 'variable', ilk='argument', name=argInfo[0]['name'])
-                    self.printTypeInfo(argInfo, argNode)
+                    argNode = SubElement( funcNode, 'variable', ilk = 'argument', name = argInfo[0]['name'] )
+                    self.printTypeInfo( argInfo, argNode )
             if self.provide_full_docs:
                 if not docString:
-                    self.printDocInfo(modInfo, funcInfo, funcNode)
+                    self.printDocInfo( modInfo, funcInfo, funcNode )
                 else:
-                    self.printDocString(docString, funcNode)
-            self.printImports(funcInfo, funcNode)
-            self.printVariables(funcInfo, funcNode)
-            
-    def tryGettingDoc_Sig(self, modInfo, funcInfo):
+                    self.printDocString( docString, funcNode )
+            self.printImports( funcInfo, funcNode )
+            self.printVariables( funcInfo, funcNode )
+
+    def tryGettingDoc_Sig( self, modInfo, funcInfo ):
         if not self.provide_full_docs:
-            return (None, None)
+            return ( None, None )
         modName = modInfo.name
         funcName = funcInfo.name
         re1_s = r"""((?:^=(?:item|head)\w*\s*
@@ -752,88 +752,88 @@ class ModuleInfo:
                       # Now the description
                       # Everything up to the an equal-sign (or end)
                       ((?:\r?\n|.)*?)(?:^=|\Z)""" % \
-                         (modName, modName, funcName, self.re_bl)
-        re1 = re_compile(re1_s, re.X|re.M)
-        re2a = re_compile(funcName + r'\s+\w')
-        re2b = re_compile(r'\s\w+\s+' + funcName + r'\b')
-        re4_s = (r'''^=(?:item|head)\s*\*?\s*\r?\n
+                         ( modName, modName, funcName, self.re_bl )
+        re1 = re_compile( re1_s, re.X | re.M )
+        re2a = re_compile( funcName + r'\s+\w' )
+        re2b = re_compile( r'\s\w+\s+' + funcName + r'\b' )
+        re4_s = ( r'''^=(?:item|head)\s*\*?\s*\r?\n
                         (?:^\s*\r?\n)*
                         ^\s*C<+(.*%s.*)>+\s*\r?\n
                         (?:^\s*\r?\n)*
                         # Now the description
                         # Everything up to the an equal-sign (or end)
-                        ((?:.*\r?\n(?!=))+)''' % (funcName,))
-        re4 = re_compile(re4_s, re.M|re.X)
+                        ((?:.*\r?\n(?!=))+)''' % ( funcName, ) )
+        re4 = re_compile( re4_s, re.M | re.X )
         for doc in modInfo.hDocs['modules'] + self.modules['main'].hDocs['modules']:
-            if doc.find(funcName) == -1:
+            if doc.find( funcName ) == -1:
                 continue
-            m1 = re1.search(doc)
+            m1 = re1.search( doc )
             if m1:
-                part1 = m1.group(1)
+                part1 = m1.group( 1 )
                 # If the function name is followed by text, it's probably
                 # an English description.  We need to check for a whole word
                 # before the name to avoid the pod directive
-                if (re2a.search(part1) or
-                    re2b.search(part1)):
+                if ( re2a.search( part1 ) or
+                    re2b.search( part1 ) ):
                     continue
-                finalDoc = self.trim_ws(self._get_first_sentence(m1.group(2)), True)
-                part2 = [s.strip() for s in self.tryGettingDoc_Sig_re3.findall(part1)]
-                finalSig = (part2 and "\n\n".join(part2)) or None
-                return (finalSig, finalDoc)
+                finalDoc = self.trim_ws( self._get_first_sentence( m1.group( 2 ) ), True )
+                part2 = [s.strip() for s in self.tryGettingDoc_Sig_re3.findall( part1 )]
+                finalSig = ( part2 and "\n\n".join( part2 ) ) or None
+                return ( finalSig, finalDoc )
             else:
-                m1 = re4.search(doc)
+                m1 = re4.search( doc )
                 if m1:
-                    finalSig = m1.group(1)
-                    finalDoc = self.trim_ws(self._get_first_sentence(m1.group(2)), True)
-                    return (finalSig, finalDoc)
-        return (None, None)
-    
+                    finalSig = m1.group( 1 )
+                    finalDoc = self.trim_ws( self._get_first_sentence( m1.group( 2 ) ), True )
+                    return ( finalSig, finalDoc )
+        return ( None, None )
+
 class NamespaceInfo:
-    def __init__(self, name, **attrInfo):
+    def __init__( self, name, **attrInfo ):
         self.name = name
-        self.line = attrInfo.get('lineNo') or 0
+        self.line = attrInfo.get( 'lineNo' ) or 0
         self.aFunc = []
         self.aVar = {}
         self.aParent = []
-        self.hDocs = {'modules':[], # hash of modules => array of docs,
-                      'subs':{}     # subs => subname => array of docs
+        self.hDocs = {'modules':[],  # hash of modules => array of docs,
+                      'subs':{}  # subs => subname => array of docs
         }
         self.aImports = []
         self._isProbablyClass = False
         self.export_info = {'@EXPORT':{},
                             '@EXPORT_OK':{}}
 
-    def isProbablyClass(self, val):
+    def isProbablyClass( self, val ):
         self._isProbablyClass = val
 
 class FunctionInfo:
-    def __init__(self, name, **attrInfo):
+    def __init__( self, name, **attrInfo ):
         self.name = name
         self.aArg = {}
         self.aVar = {}
         self.resultType = []
         self.argList = []
         self.aImports = []
-        self.isConstructor = attrInfo.get('isConstructor', False)
-        if attrInfo.has_key('lineNo'):
-            self.line = attrInfo.get('lineNo')
-    
+        self.isConstructor = attrInfo.get( 'isConstructor', False )
+        if attrInfo.has_key( 'lineNo' ):
+            self.line = attrInfo.get( 'lineNo' )
+
 if not os.path.altsep or os.path.altsep == os.path.sep:
-    def pathSplitter(s):
-        return s.split(os.path.sep)
+    def pathSplitter( s ):
+        return s.split( os.path.sep )
 else:
-    def pathSplitter(s):
-        return re.split(re_compile('[' + re.escape(os.path.sep)
-                                   + re.escape(os.path.altsep) + ']'), s)
+    def pathSplitter( s ):
+        return re.split( re_compile( '[' + re.escape( os.path.sep )
+                                   + re.escape( os.path.altsep ) + ']' ), s )
 
 class Parser:
-    def __init__(self, tokenizer, lang="Perl", provide_full_docs=True):
+    def __init__( self, tokenizer, lang = "Perl", provide_full_docs = True ):
         self.tokenizer = tokenizer
         self._provide_full_docs = provide_full_docs
         self.block_stack = []
         self.bracket_matchers = {"[":"]", "{":"}", "(":")"}
-        self.classifier = _get_classifier(lang)
-        
+        self.classifier = _get_classifier( lang )
+
         # Use simple knowledge of Perl's syntax
         # to skip quickly through code to skip.
         self.opHash = {"(" : [0, 1],
@@ -875,171 +875,171 @@ class Parser:
                             'vmsish' : None,
                             'warnings' : None,
                             }
-        self.find_open_indexer_re = re_compile(r'[\[{]')
+        self.find_open_indexer_re = re_compile( r'[\[{]' )
         self.provide_full_docs = provide_full_docs
 
-    def _is_stmt_end_op(self, tok):
+    def _is_stmt_end_op( self, tok ):
         tval = tok.text
-        if self.classifier.is_keyword(tok, 'or'):
+        if self.classifier.is_keyword( tok, 'or' ):
             return True
-        elif self.classifier.is_any_operator(tok):
-            return tval in (';', '||')
+        elif self.classifier.is_any_operator( tok ):
+            return tval in ( ';', '||' )
         return False
 
-    def _is_string(self, tok):
+    def _is_string( self, tok ):
         return tok.style in self.tokenizer.string_types
-        
-        
-    def printHeader(self, mtime):
+
+
+    def printHeader( self, mtime ):
         moduleName = self.moduleName
-        root = Element("codeintel", version="2.0")
-        fileNode = Element("file", lang="Perl",
-                           path=moduleName)
+        root = Element( "codeintel", version = "2.0" )
+        fileNode = Element( "file", lang = "Perl",
+                           path = moduleName )
         if mtime:
-            fileNode.set('mtime', str(mtime))
-        root.append(fileNode)
-        return (root, fileNode)
-        
-    def printContents(self, moduleContentsName, currNode):
-        name = os.path.splitext(os.path.basename(self.moduleName))[0]
-        moduleNode = SubElement(currNode, 'scope', ilk='blob', lang="Perl", name=name)
-        
+            fileNode.set( 'mtime', str( mtime ) )
+        root.append( fileNode )
+        return ( root, fileNode )
+
+    def printContents( self, moduleContentsName, currNode ):
+        name = os.path.splitext( os.path.basename( self.moduleName ) )[0]
+        moduleNode = SubElement( currNode, 'scope', ilk = 'blob', lang = "Perl", name = name )
+
         innerModules = self.moduleInfo.modules
-        mainInfo = innerModules.get('main', None)
+        mainInfo = innerModules.get( 'main', None )
         if mainInfo:
             if self.provide_full_docs:
-                self.moduleInfo.printDocInfo(mainInfo, None, moduleNode)
-            self.moduleInfo.printImports(mainInfo, moduleNode)
-            self.moduleInfo.printVariables(mainInfo, moduleNode)
-        
-        def sorter1(a,b):
-            amod = innerModules.get(a)
-            bmod = innerModules.get(b)
-            aline = getattr(amod, 'line', None)
+                self.moduleInfo.printDocInfo( mainInfo, None, moduleNode )
+            self.moduleInfo.printImports( mainInfo, moduleNode )
+            self.moduleInfo.printVariables( mainInfo, moduleNode )
+
+        def sorter1( a, b ):
+            amod = innerModules.get( a )
+            bmod = innerModules.get( b )
+            aline = getattr( amod, 'line', None )
             if aline:
-                bline = getattr(bmod, 'line', None)
-                if aline and bline: return cmp(aline, bline)
-            return cmp(getattr(amod, 'name', ""), getattr(bmod, 'name', ""))
-        
+                bline = getattr( bmod, 'line', None )
+                if aline and bline: return cmp( aline, bline )
+            return cmp( getattr( amod, 'name', "" ), getattr( bmod, 'name', "" ) )
+
         # Sub-packages need to updated their parent blob name - bug 88814.
         # I.e. when parsing "XML/Simple.pm" the blob name is "Simple", but we
         #      need it be "XML::Simple" in this case. The bestPackageName is
         #      used to find the best matching name.
         packages = [x for x in self.moduleInfo.modules.keys() if x != 'main']
-        packages.sort(sorter1)
+        packages.sort( sorter1 )
         bestPackageName = None
         for k in packages:
             modInfo = innerModules[k]
 
             if name in k and \
-               (bestPackageName is None or len(bestPackageName) > k):
+               ( bestPackageName is None or len( bestPackageName ) > k ):
                 bestPackageName = k
-                moduleNode.set("name", bestPackageName)
+                moduleNode.set( "name", bestPackageName )
 
-            classNode = SubElement(moduleNode, 'scope', ilk='class', name=modInfo.name, line=str(modInfo.line))
-            if hasattr(modInfo, 'lineend'):
-                classNode.set('lineend', str(modInfo.lineend))
-            self.moduleInfo.printClassParents(modInfo, classNode)
+            classNode = SubElement( moduleNode, 'scope', ilk = 'class', name = modInfo.name, line = str( modInfo.line ) )
+            if hasattr( modInfo, 'lineend' ):
+                classNode.set( 'lineend', str( modInfo.lineend ) )
+            self.moduleInfo.printClassParents( modInfo, classNode )
             if self.provide_full_docs:
-                self.moduleInfo.printDocInfo(modInfo, None, classNode)
-            self.moduleInfo.printImports(modInfo, classNode)
-            self.moduleInfo.printVariables(modInfo, classNode)
-            self.moduleInfo.printFunctions(modInfo, classNode)
+                self.moduleInfo.printDocInfo( modInfo, None, classNode )
+            self.moduleInfo.printImports( modInfo, classNode )
+            self.moduleInfo.printVariables( modInfo, classNode )
+            self.moduleInfo.printFunctions( modInfo, classNode )
 
         # And do main's functions after its classes
         if mainInfo:
-            self.moduleInfo.printFunctions(mainInfo, moduleNode)
+            self.moduleInfo.printFunctions( mainInfo, moduleNode )
 
-    def printTrailer(self, root):
+    def printTrailer( self, root ):
         pass
 
-    def at_end_expression(self, tok):
-        if not self.classifier.is_any_operator(tok):
+    def at_end_expression( self, tok ):
+        if not self.classifier.is_any_operator( tok ):
             return False
-        return tok.text in (';', ',', '}')
+        return tok.text in ( ';', ',', '}' )
 
-        
-    def collect_multiple_args(self, origLineNo, context, var_scope):
+
+    def collect_multiple_args( self, origLineNo, context, var_scope ):
         nameList = []
         while True:
             tok = self.tokenizer.get_next_token()
-            if self.classifier.is_variable(tok):
-                nameList.append((tok.text, tok.start_line))
+            if self.classifier.is_variable( tok ):
+                nameList.append( ( tok.text, tok.start_line ) )
             else:
                 break
             tok = self.tokenizer.get_next_token()
-            if self.classifier.is_any_operator(tok):
+            if self.classifier.is_any_operator( tok ):
                 tval = tok.text
                 if tval == ")": break
                 elif tval != ",": break
-        if not self.classifier.is_operator(tok, ")"):
+        if not self.classifier.is_operator( tok, ")" ):
             return
         tok = self.tokenizer.get_next_token()
         isArg = False
-        if self.classifier.is_operator(tok, "="):
+        if self.classifier.is_operator( tok, "=" ):
             tok = self.tokenizer.get_next_token()
-            if self.classifier.is_variable_array(tok, self.classifier.is_array_cb) and tok.text == "@_":
+            if self.classifier.is_variable_array( tok, self.classifier.is_array_cb ) and tok.text == "@_":
                 tok = self.tokenizer.get_next_token()
-                isArg = self._is_stmt_end_op(tok)
+                isArg = self._is_stmt_end_op( tok )
             else:
-                tok = self.tokenizer.put_back(tok)
+                tok = self.tokenizer.put_back( tok )
         for varInfo in nameList:
-            if isArg: self.moduleInfo.doSetArg(varInfo[0])
-            self.moduleInfo.doSetVar(name=varInfo[0], line=varInfo[1],
-                                     scope=var_scope)
+            if isArg: self.moduleInfo.doSetArg( varInfo[0] )
+            self.moduleInfo.doSetVar( name = varInfo[0], line = varInfo[1],
+                                     scope = var_scope )
     # end collect_multiple_args
-    
+
     # Expect = shift ;
-    def collect_single_arg(self, varName, origLineNo, context, var_scope):
+    def collect_single_arg( self, varName, origLineNo, context, var_scope ):
         tok = self.tokenizer.get_next_token()
-        if not self.classifier.is_operator(tok, '='):
+        if not self.classifier.is_operator( tok, '=' ):
             isArg = False
         else:
             tok = self.tokenizer.get_next_token()
-            if self.classifier.is_keyword(tok, 'shift') or tok.text == '@_':
+            if self.classifier.is_keyword( tok, 'shift' ) or tok.text == '@_':
                 tok = self.tokenizer.get_next_token()
-                isArg = self._is_stmt_end_op(tok)
-                self.tokenizer.put_back(tok)
+                isArg = self._is_stmt_end_op( tok )
+                self.tokenizer.put_back( tok )
             else:
-                self.tokenizer.put_back(tok)
-                self.finish_var_assignment(varName, origLineNo, False,
-                                           scope=var_scope, context=context)
+                self.tokenizer.put_back( tok )
+                self.finish_var_assignment( varName, origLineNo, False,
+                                           scope = var_scope, context = context )
                 return
         if isArg:
-            self.moduleInfo.doSetArg(varName)
-        self.moduleInfo.doSetVar(name=varName, line=origLineNo,
-                                 scope=var_scope)
-        
-    def de_quote_string(self, tok):
+            self.moduleInfo.doSetArg( varName )
+        self.moduleInfo.doSetVar( name = varName, line = origLineNo,
+                                 scope = var_scope )
+
+    def de_quote_string( self, tok ):
         tval = tok.text
-        patterns = self.classifier.get_quote_patterns(tok, self.classifier.quote_patterns_cb)
+        patterns = self.classifier.get_quote_patterns( tok, self.classifier.quote_patterns_cb )
         for p in patterns:
-            m = p.match(tval)
+            m = p.match( tval )
             if m:
-                return m.group(1)
+                return m.group( 1 )
         return tval
-    
+
     # Called from both assignments and
 # my <var> = ... statements, where the RHS isn't 'shift' or '@_';
-    def finish_var_assignment(self, identifier, origLineNo, forceGlobal, **inherited_args):
+    def finish_var_assignment( self, identifier, origLineNo, forceGlobal, **inherited_args ):
         tok = self.tokenizer.get_next_token()
-    
+
         # Narrow down to these possibilities:
-    
+
         # 1. We're assigning a method call to a scalar
-    
+
         # $lhs = $rhs->method()->{property}->...
         #
         # Reduces to
         # $lhs = $rhs
-        
+
         # 2. We're assigning a string/int -- i.e., it's likely
         # to be a non-object value:
-        
+
         # $lhs = "acb" eq $q
         # $lhs = $r
         # $lhs = 42
-        
+
         # 3. We're assigning a constructor
         # Now we can take two forms:
         # <constructor> <subpath>
@@ -1047,117 +1047,117 @@ class Parser:
         # Note that if we don't know anything about the module, we can't say
         # anything intelligent about Package::Midd::Function -- we don't know
         # if this returns a constructor or not, although it likely doesn't.
-        
+
         rhs_StarterVal = None
         args = { 'name':identifier, 'line':origLineNo,
                 'forceGlobal':forceGlobal }
         if inherited_args:
-            args.update(inherited_args)
+            args.update( inherited_args )
         ttype = tok.style
-        if self.classifier.is_variable_scalar(tok, self.classifier.is_scalar_cb):
+        if self.classifier.is_variable_scalar( tok, self.classifier.is_scalar_cb ):
             rhs_StarterVal = tok.text
             tok = self.tokenizer.get_next_token()
             # Check and skip indexers
-            if self.classifier.is_index_op(tok, self.find_open_indexer_re):
+            if self.classifier.is_index_op( tok, self.find_open_indexer_re ):
                 self.skip_to_close_match()
                 tok = self.tokenizer.get_next_token()
-                
+
             # Now get the list of accessors that take us to the
             # semi-colon or close-brace.  Hop over arg lists.
             # Left looking at ->, ;, }, or leave
-            
+
             accessors = []
-            while self.classifier.is_operator(tok, "->") or self.classifier.is_index_op(tok, self.find_open_indexer_re):
+            while self.classifier.is_operator( tok, "->" ) or self.classifier.is_index_op( tok, self.find_open_indexer_re ):
                 if tok.text == "->":
                     tok = self.tokenizer.get_next_token()
-                if self.classifier.is_index_op(tok, self.find_open_indexer_re):
+                if self.classifier.is_index_op( tok, self.find_open_indexer_re ):
                     propertyName = self._get_property_token()
                     if not propertyName:
                         break
-                    accessors.append(propertyName)
+                    accessors.append( propertyName )
                     tok = self.tokenizer.get_next_token()
-                elif not self.classifier.is_identifier_or_keyword(tok):
+                elif not self.classifier.is_identifier_or_keyword( tok ):
                     break
                 else:
-                    fqName = self.get_rest_of_subpath(tok.text, 1)
-                    accessors.append(fqName)
+                    fqName = self.get_rest_of_subpath( tok.text, 1 )
+                    accessors.append( fqName )
                     tok = self.tokenizer.get_next_token()
-                if self.classifier.is_operator(tok, "("):
+                if self.classifier.is_operator( tok, "(" ):
                     self.skip_to_close_paren()
                     tok = self.tokenizer.get_next_token()
             # end while
-            
-            if accessors or self.at_end_expression(tok):
-                if self.at_end_expression(tok):
-                    self.tokenizer.put_back(tok)
-                fqname = (accessors and rhs_StarterVal.join(accessors)) or rhs_StarterVal
-            self.moduleInfo.doSetVar(**args)
-            
-        elif self.classifier.is_number(tok):
-            #XXX: Any expressions starting with an integer that
+
+            if accessors or self.at_end_expression( tok ):
+                if self.at_end_expression( tok ):
+                    self.tokenizer.put_back( tok )
+                fqname = ( accessors and rhs_StarterVal.join( accessors ) ) or rhs_StarterVal
+            self.moduleInfo.doSetVar( **args )
+
+        elif self.classifier.is_number( tok ):
+            # XXX: Any expressions starting with an integer that
             # don't yield an int value?
             tok = self.tokenizer.get_next_token()
-            if self.at_end_expression(tok):
-                self.tokenizer.put_back(tok)
-            self.moduleInfo.doSetVar(**args)
-        elif self._is_string(tok):
+            if self.at_end_expression( tok ):
+                self.tokenizer.put_back( tok )
+            self.moduleInfo.doSetVar( **args )
+        elif self._is_string( tok ):
             tok = self.tokenizer.get_next_token()
-            if self.at_end_expression(tok):
-                self.tokenizer.put_back(tok)
-            self.moduleInfo.doSetVar(**args)
-        elif self.classifier.is_identifier(tok):
+            if self.at_end_expression( tok ):
+                self.tokenizer.put_back( tok )
+            self.moduleInfo.doSetVar( **args )
+        elif self.classifier.is_identifier( tok ):
             rhs_StarterVal = tok.text
             tok = self.tokenizer.get_next_token()
             updateVarInfo = None
-            if self.classifier.is_operator(tok, "::"):
+            if self.classifier.is_operator( tok, "::" ):
                 # Package->method  or Package::method notation
-                rhs_StarterVal = self.get_rest_of_subpath(rhs_StarterVal + '::', 0)
+                rhs_StarterVal = self.get_rest_of_subpath( rhs_StarterVal + '::', 0 )
                 tok = self.tokenizer.get_next_token()
-            if self.classifier.is_operator(tok, "->"):
+            if self.classifier.is_operator( tok, "->" ):
                 # a->b is always good
                 tok = self.tokenizer.get_next_token()
-                if self.classifier.is_identifier_or_keyword(tok) and tok.text == "new":
+                if self.classifier.is_identifier_or_keyword( tok ) and tok.text == "new":
                     # 80/20 rule: assume a new on a class gives an instance
                     args['aType'] = {'assign' : rhs_StarterVal }
-            elif self.classifier.is_identifier_or_keyword(tok):
-                if rhs_StarterVal.find("::") > -1:
+            elif self.classifier.is_identifier_or_keyword( tok ):
+                if rhs_StarterVal.find( "::" ) > -1:
                     # obj A::B is always good
                     pass
                 elif rhs_StarterVal == 'new':
                     # 80/20 rule
                     package_name = tok.text
                     tok = self.tokenizer.get_next_token()
-                    if self.classifier.is_operator(tok, "::"):
+                    if self.classifier.is_operator( tok, "::" ):
                         # new Package notation
-                        package_name = self.get_rest_of_subpath(package_name + '::', 0)
+                        package_name = self.get_rest_of_subpath( package_name + '::', 0 )
                         tok = self.tokenizer.get_next_token()
                     args['aType'] = {'assign' : package_name }
-            self.moduleInfo.doSetVar(**args)
-        elif self.classifier.is_keyword(tok, 'bless') and self.moduleInfo.currentFunction:
+            self.moduleInfo.doSetVar( **args )
+        elif self.classifier.is_keyword( tok, 'bless' ) and self.moduleInfo.currentFunction:
             self.moduleInfo.currentFunction.isConstructor = True
-            self.moduleInfo.doSetVar(**args)
-        elif self.classifier.is_keyword(tok, 'new'):
+            self.moduleInfo.doSetVar( **args )
+        elif self.classifier.is_keyword( tok, 'new' ):
             tok = self.tokenizer.get_next_token()
-            if self.classifier.is_identifier(tok):
+            if self.classifier.is_identifier( tok ):
                 package_name = tok.text
                 tok = self.tokenizer.get_next_token()
             else:
                 package_name = ""
-            if self.classifier.is_operator(tok, "::"):
-                package_name = self.get_rest_of_subpath(package_name + '::', 0)
+            if self.classifier.is_operator( tok, "::" ):
+                package_name = self.get_rest_of_subpath( package_name + '::', 0 )
             if package_name != "":
                 args['aType'] = {'assign': package_name}
-                self.moduleInfo.doSetVar(**args)
+                self.moduleInfo.doSetVar( **args )
         else:
-            self.moduleInfo.doSetVar(**args)
-            if self.classifier.is_index_op(tok, self.find_open_indexer_re):
-                self.tokenizer.put_back(tok)
+            self.moduleInfo.doSetVar( **args )
+            if self.classifier.is_index_op( tok, self.find_open_indexer_re ):
+                self.tokenizer.put_back( tok )
     # end finish_var_assignment
-    
-    def get_exported_names(self, export_keyword):
+
+    def get_exported_names( self, export_keyword ):
         tok = self.tokenizer.get_next_token()
-        if not self.classifier.is_operator(tok, '='):
-            self.tokenizer.put_back(tok)
+        if not self.classifier.is_operator( tok, '=' ):
+            self.tokenizer.put_back( tok )
             return
         names = self.get_list_of_strings()
         for obj in names:
@@ -1166,106 +1166,106 @@ class Parser:
             self.moduleInfo.currentNS.export_info[export_keyword][name] = None
     # end export_keyword
 
-    def get_for_vars(self):
+    def get_for_vars( self ):
         tok = self.tokenizer.get_next_token()
-        if (tok.style == ScintillaConstants.SCE_PL_WORD
-            and tok.text in ('my', 'state')):
+        if ( tok.style == ScintillaConstants.SCE_PL_WORD
+            and tok.text in ( 'my', 'state' ) ):
             tlineNo = tok.start_line
             tok = self.tokenizer.get_next_token()
-            if self.classifier.is_variable(tok):
+            if self.classifier.is_variable( tok ):
                 # Don't do any more processing, as we're probably looking
                 # at an open-paren.
-                self.moduleInfo.doSetVar(name=tok.text, line=tlineNo, scope='my')
-    
-    def get_list_of_var_names(self):
+                self.moduleInfo.doSetVar( name = tok.text, line = tlineNo, scope = 'my' )
+
+    def get_list_of_var_names( self ):
         resArray = []
         while 1:
             tok = self.tokenizer.get_next_token()
-            if self.classifier.is_variable(tok):
-                resArray.append([tok.text, tok.start_line])
+            if self.classifier.is_variable( tok ):
+                resArray.append( [tok.text, tok.start_line] )
             else:
                 break
             tok = self.tokenizer.get_next_token()
-            if not self.classifier.is_operator(tok, ","):
+            if not self.classifier.is_operator( tok, "," ):
                 break
         return resArray
-    
-    def get_list_of_strings(self, tok=None):
+
+    def get_list_of_strings( self, tok = None ):
         if tok is None:
             tok = self.tokenizer.get_next_token()
-        if self.classifier.is_operator(tok, "("):
+        if self.classifier.is_operator( tok, "(" ):
             resArray = []
             while 1:
                 # Simple -- either a string or a qw here as well
                 tok = self.tokenizer.get_next_token()
-                if self._is_string(tok):
-                    resArray += self.get_string_array(tok)
+                if self._is_string( tok ):
+                    resArray += self.get_string_array( tok )
                 else:
                     break
                 tok = self.tokenizer.get_next_token()
-                if self.classifier.is_any_operator(tok):
+                if self.classifier.is_any_operator( tok ):
                     if tok.text == ")":
                         break
                     elif tok.text == ",":
                         continue
                     break
-        elif self._is_string(tok):
-            resArray = self.get_string_array(tok)
+        elif self._is_string( tok ):
+            resArray = self.get_string_array( tok )
         else:
             return []
         return resArray
     # end get_list_of_strings
-    
-    def get_our_vars(self, context, var_scope):
+
+    def get_our_vars( self, context, var_scope ):
         tok = self.tokenizer.get_next_token()
         varNames = []
-        if self.classifier.is_operator(tok, "("):
+        if self.classifier.is_operator( tok, "(" ):
             varNames = self.get_list_of_var_names()
-        elif self.classifier.is_variable(tok):
+        elif self.classifier.is_variable( tok ):
             tval = tok.text.strip()
             if tval == '@ISA':
-                self.get_parent_namespaces(True)
+                self.get_parent_namespaces( True )
             else:
                 lineNo = tok.start_line
                 tok = self.tokenizer.get_next_token()
-                if self.classifier.is_operator(tok, "="):
-                    self.finish_var_assignment(tval, lineNo, 0, scope=var_scope, context=context)
+                if self.classifier.is_operator( tok, "=" ):
+                    self.finish_var_assignment( tval, lineNo, 0, scope = var_scope, context = context )
                     return
-                varNames = [(tval, lineNo)]
+                varNames = [( tval, lineNo )]
         for varInfo in varNames:
-            self.moduleInfo.doSetVar(name=varInfo[0], line=varInfo[1], scope=var_scope)
-    
+            self.moduleInfo.doSetVar( name = varInfo[0], line = varInfo[1], scope = var_scope )
+
     # Look for = stringList...
-    def get_parent_namespaces(self, doingIsa):
+    def get_parent_namespaces( self, doingIsa ):
         tok = self.tokenizer.get_next_token()
         if doingIsa:
-            if not self.classifier.is_operator(tok, '='):
-                self.tokenizer.put_back(tok)
+            if not self.classifier.is_operator( tok, '=' ):
+                self.tokenizer.put_back( tok )
                 return
         parentNamespaces = self.get_list_of_strings()
         for parentInfo in parentNamespaces:
-            self.moduleInfo.currentNS.aParent.append(parentInfo)
-            
+            self.moduleInfo.currentNS.aParent.append( parentInfo )
+
         # Undocumented attribute, but it means one of the methods
         # should either invoke bless, SUPER:: ..., or a parent
         # constructor.
-        self.moduleInfo.currentNS.isProbablyClass(True)
+        self.moduleInfo.currentNS.isProbablyClass( True )
     # end get_parent_namespaces
-    
+
     # Precondition: saw ident, "->", '{'
     # Still looking at the "{"
-    def _get_property_token(self):
+    def _get_property_token( self ):
         tok = self.tokenizer.get_next_token()
-        if self._is_string(tok):
-            finalVal = self.de_quote_string(tok)
-        elif not (self.classifier.is_identifier_or_keyword(tok) or
-                  self.classifier.is_variable_scalar(tok, self.classifier.is_scalar_cb)):
+        if self._is_string( tok ):
+            finalVal = self.de_quote_string( tok )
+        elif not ( self.classifier.is_identifier_or_keyword( tok ) or
+                  self.classifier.is_variable_scalar( tok, self.classifier.is_scalar_cb ) ):
             return ""
         else:
             finalVal = tok.text
         tok = self.tokenizer.get_next_token()
-        
-        if not self.classifier.is_index_op(tok, re_compile(r'\}')):
+
+        if not self.classifier.is_index_op( tok, re_compile( r'\}' ) ):
             # Swallow the close-brace for the property.
             finalVal = "???";
             # Consume everything until we find the close-brace
@@ -1273,199 +1273,199 @@ class Parser:
                 tok = self.tokenizer.get_next_token()
                 if tok.style == SCE_PL_UNUSED:
                     break
-                elif self.classifier.is_index_op(tok, re_compile(r'[\}\]]')):
+                elif self.classifier.is_index_op( tok, re_compile( r'[\}\]]' ) ):
                     break
         return finalVal
 
-    def get_rest_of_subpath(self, retval, expectingDblColon):
+    def get_rest_of_subpath( self, retval, expectingDblColon ):
         if expectingDblColon:
             tok = self.tokenizer.get_next_token()
             ttype = tok.style
             tval = tok.text
-            if not self.classifier.is_operator(tok, "::"):
-                self.tokenizer.put_back(tok)
+            if not self.classifier.is_operator( tok, "::" ):
+                self.tokenizer.put_back( tok )
                 return retval
             else:
                 retval += "::"
-            
+
         while 1:
             tok = self.tokenizer.get_next_token()
             ttype = tok.style
-            if not self.classifier.is_identifier(tok):
-                if ttype != self.classifier.style_word or len(retval) == 0:
+            if not self.classifier.is_identifier( tok ):
+                if ttype != self.classifier.style_word or len( retval ) == 0:
                     break
             retval += tok.text
             tok = self.tokenizer.get_next_token()
-            if not self.classifier.is_operator(tok, "::"):
+            if not self.classifier.is_operator( tok, "::" ):
                 break
             retval += "::"
-            
-        self.tokenizer.put_back(tok)
+
+        self.tokenizer.put_back( tok )
         return retval
     # end get_rest_of_subpath
-    
-    def get_string_array(self, tok):
-        if self.classifier.is_string_qw(tok, self.classifier.is_string_qw_cb):
+
+    def get_string_array( self, tok ):
+        if self.classifier.is_string_qw( tok, self.classifier.is_string_qw_cb ):
             res = []
-            qw_re = re_compile(r'\Aqw\s*.(.*)\s*\S\s*\Z', re.DOTALL)
-            match_res = qw_re.match(tok.text)
+            qw_re = re_compile( r'\Aqw\s*.(.*)\s*\S\s*\Z', re.DOTALL )
+            match_res = qw_re.match( tok.text )
             if match_res:
-                wordsPart = match_res.group(1)
+                wordsPart = match_res.group( 1 )
                 # Find first line of token
                 finalLineNo = tok.start_line
-                for line in wordsPart.split('\n'):
-                    for var in re.split(r'\s', line):
-                        if re_compile(r'\s*$').match(var):
+                for line in wordsPart.split( '\n' ):
+                    for var in re.split( r'\s', line ):
+                        if re_compile( r'\s*$' ).match( var ):
                             continue
-                        res.append((var, finalLineNo))
+                        res.append( ( var, finalLineNo ) )
                     finalLineNo += 1
             return res
         else:
-            tval = self.de_quote_string(tok)
-            return [(tval, tok.start_line)]
-        
-    def get_used_vars(self, scope):
+            tval = self.de_quote_string( tok )
+            return [( tval, tok.start_line )]
+
+    def get_used_vars( self, scope ):
         tok = self.tokenizer.get_next_token()
-        if self._is_string(tok):
-            varNames = self.get_list_of_strings(tok)
-        elif self.classifier.is_operator(tok, "("):
+        if self._is_string( tok ):
+            varNames = self.get_list_of_strings( tok )
+        elif self.classifier.is_operator( tok, "(" ):
             varNames = self.get_list_of_strings()
         else:
             varNames = self.get_list_of_var_names()
         for varInfo in varNames:
-            self.moduleInfo.doSetVar(name=varInfo[0],
-                                     line=varInfo[1],
-                                     scope=scope)
-    
-    def look_for_object_var_assignment(self, tok, isInnerSub):
+            self.moduleInfo.doSetVar( name = varInfo[0],
+                                     line = varInfo[1],
+                                     scope = scope )
+
+    def look_for_object_var_assignment( self, tok, isInnerSub ):
         identifier = tok.text
-        if re_compile(r'^\$[^_\w]').match(identifier) or identifier == '$_':
+        if re_compile( r'^\$[^_\w]' ).match( identifier ) or identifier == '$_':
             # Ignore special variables, and $#$... array ref final-item index
             return
         origLineNo = tok.start_line
         tok = self.tokenizer.get_next_token()
-        if not self.classifier.is_index_op(tok):
-            self.tokenizer.put_back(tok)
+        if not self.classifier.is_index_op( tok ):
+            self.tokenizer.put_back( tok )
             return
         elif tok.text != '=':
-            self.tokenizer.put_back(tok)
+            self.tokenizer.put_back( tok )
             return
         # Is it an implicit global?
         checkGlobalScope = True
         forceGlobal = False
-        #XXX Update, check this
+        # XXX Update, check this
         if self.moduleInfo.currentFunction:
             # Is it defined in the current function?
-            if (self.moduleInfo.currentFunction.aVar.has_key(identifier) or
-                self.moduleInfo.currentFunction.aArg.has_key(identifier)):
+            if ( self.moduleInfo.currentFunction.aVar.has_key( identifier ) or
+                self.moduleInfo.currentFunction.aArg.has_key( identifier ) ):
                 checkGlobalScope = False
                 # Defined in current function.
             elif isInnerSub:
                 checkGlobalScope = False
                 # Assume that it's defined in the containing sub
         if checkGlobalScope:
-            if not self.moduleInfo.currentNS.aVar.has_key(identifier):
+            if not self.moduleInfo.currentNS.aVar.has_key( identifier ):
                 self.moduleInfo.currentNS.aVar[identifier] = [{'name':identifier,
                                                                'line':origLineNo}]
             forceGlobal = True
-        self.finish_var_assignment(identifier, origLineNo, forceGlobal)
+        self.finish_var_assignment( identifier, origLineNo, forceGlobal )
     # end look_for_object_var_assignment
 
     # Handle arrays, hashes, typeglobs, but don't bother figuring out a type.
     # No 'my', 'our', 'state', or 'use vars' given
-    def look_for_var_assignment(self, tok1):
+    def look_for_var_assignment( self, tok1 ):
         # First make sure this var hasn't already been defined
         # Is it an implicit global?
         var_name = tok1.text
-        if len(var_name) < 2 or var_name[1] == '$':
+        if len( var_name ) < 2 or var_name[1] == '$':
             return
         if self.moduleInfo.currentFunction:
             # Is it defined in the current function?
-            if (self.moduleInfo.currentFunction.aVar.has_key(var_name) or
-                self.moduleInfo.currentFunction.aArg.has_key(var_name)):
+            if ( self.moduleInfo.currentFunction.aVar.has_key( var_name ) or
+                self.moduleInfo.currentFunction.aArg.has_key( var_name ) ):
                 return
             scope = 'my'
         else:
             scope = 'our'
-        if self.moduleInfo.currentNS.aVar.has_key(var_name):
+        if self.moduleInfo.currentNS.aVar.has_key( var_name ):
             return
         tok2 = self.tokenizer.get_next_token()
-        if self.classifier.is_operator(tok2, "="):
-            varInfo = (tok1.text, tok1.start_line)
-            self.moduleInfo.doSetVar(name=var_name, line=tok1.start_line,
-                                     scope=scope)
+        if self.classifier.is_operator( tok2, "=" ):
+            varInfo = ( tok1.text, tok1.start_line )
+            self.moduleInfo.doSetVar( name = var_name, line = tok1.start_line,
+                                     scope = scope )
         else:
-            self.tokenizer.put_back(tok2)
+            self.tokenizer.put_back( tok2 )
 
-    def process_import(self, fqModule, origLineNo, import_vars=None):
+    def process_import( self, fqModule, origLineNo, import_vars = None ):
         tok = self.tokenizer.get_next_token()
-        if self._is_string(tok) or self.classifier.is_operator(tok, "("):
-            varNames = self.get_list_of_strings(tok)
+        if self._is_string( tok ) or self.classifier.is_operator( tok, "(" ):
+            varNames = self.get_list_of_strings( tok )
             imports_nothing = not varNames
         else:
-            self.tokenizer.put_back(tok)
+            self.tokenizer.put_back( tok )
             varNames = []
             imports_nothing = None
         args = {'module':fqModule, 'line':origLineNo}
         if not varNames:
             if import_vars and not imports_nothing:
                 args['symbol'] = '*'
-            self.moduleInfo.add_imported_module(args)
+            self.moduleInfo.add_imported_module( args )
         elif [x[0] for x in varNames if x[0][0] == ":"]:
             # If there's a tag, assume we're just bringing in all exported names.
             if import_vars:
                 args['symbol'] = '**'
-            self.moduleInfo.add_imported_module(args)
+            self.moduleInfo.add_imported_module( args )
         else:
             for varName in varNames:
-                self.moduleInfo.add_imported_module(args, line=varName[1], symbol=varName[0])
+                self.moduleInfo.add_imported_module( args, line = varName[1], symbol = varName[0] )
     # end process_import
-    
-    def process_module(self, moduleName, mtime, _showWarnings=False):
-        showWarnings=_showWarnings
+
+    def process_module( self, moduleName, mtime, _showWarnings = False ):
+        showWarnings = _showWarnings
         self.moduleName = moduleName
         self.parse()
-        xmlTree = self.get_CIX(mtime)
+        xmlTree = self.get_CIX( mtime )
         return xmlTree
 
-    def get_CIX(self, mtime=None):
-        (root, currNode) = self.printHeader(mtime)
-        self.printContents(self.moduleName, currNode)
-        self.printTrailer(root)
+    def get_CIX( self, mtime = None ):
+        ( root, currNode ) = self.printHeader( mtime )
+        self.printContents( self.moduleName, currNode )
+        self.printTrailer( root )
         return root
 
-    def produce_CIX(self, actual_mtime=None):
-        return self.get_CIX(actual_mtime)
+    def produce_CIX( self, actual_mtime = None ):
+        return self.get_CIX( actual_mtime )
 
-    def produce_CIX_NoHeader(self, cix_node):
+    def produce_CIX_NoHeader( self, cix_node ):
         """Get the CIX for the current contents, and attach it to the cix_node.
         """
-        self.printContents(self.moduleName, cix_node)
+        self.printContents( self.moduleName, cix_node )
 
     # Codeintel interface to the parser
-    def parse(self):
+    def parse( self ):
         origLineNo = self.tokenizer.curr_line_no()
-        self.moduleInfo = ModuleInfo(self.provide_full_docs)
-        self.moduleInfo.doStartNS(NamespaceInfo(name='main', lineNo=origLineNo))
-        self.process_package_inner_contents(True)
+        self.moduleInfo = ModuleInfo( self.provide_full_docs )
+        self.moduleInfo.doStartNS( NamespaceInfo( name = 'main', lineNo = origLineNo ) )
+        self.process_package_inner_contents( True )
         if self.provide_full_docs:
             # Check for a trailing pod doc
-            podName = re_sub(r'.p[ml]$', '.pod', self.moduleName)
-            if not os.path.isfile(podName) and os.path.isfile(os.path.join('..', 'test', podName)):
-                podName = os.path.join('..', 'test', podName)
-            if os.path.isfile(podName):
+            podName = re_sub( r'.p[ml]$', '.pod', self.moduleName )
+            if not os.path.isfile( podName ) and os.path.isfile( os.path.join( '..', 'test', podName ) ):
+                podName = os.path.join( '..', 'test', podName )
+            if os.path.isfile( podName ):
                 try:
-                    f = open(podName)
+                    f = open( podName )
                     pod_str = f.read()
                     f.close()
-                    self.moduleInfo.currentNS.hDocs['modules'].append(pod_str)
+                    self.moduleInfo.currentNS.hDocs['modules'].append( pod_str )
                 except:
                     pass
-        self.moduleInfo.doEndNS(lineNo = self.tokenizer.curr_line_no())
-        
-        
-    
-    def process_package_inner_contents(self, doingTopLevel):
+        self.moduleInfo.doEndNS( lineNo = self.tokenizer.curr_line_no() )
+
+
+
+    def process_package_inner_contents( self, doingTopLevel ):
         currPackage = self.moduleInfo.currentNS
         popNS = 0
         curr_pkg_line_no = self.tokenizer.curr_line_no()
@@ -1477,75 +1477,75 @@ class Parser:
             tval = tok.text
             if ttype == self.classifier.style_word:
                 if tval == 'package':
-                    packageName = self.get_rest_of_subpath("", 0)
+                    packageName = self.get_rest_of_subpath( "", 0 )
                     if packageName:
-                        self.moduleInfo.doEndNS(lineNo=curr_pkg_line_no)
-                        ns = self.moduleInfo.getNS(packageName,
-                                                   lineNo=self.tokenizer.curr_line_no())
-                        self.moduleInfo.doStartNS(ns)
+                        self.moduleInfo.doEndNS( lineNo = curr_pkg_line_no )
+                        ns = self.moduleInfo.getNS( packageName,
+                                                   lineNo = self.tokenizer.curr_line_no() )
+                        self.moduleInfo.doStartNS( ns )
                         popNS = 1
-                elif tval == 'sub':
-                    self.start_process_sub_definition(False); # Is outer sub
+                elif tval in ( 'sub', 'func', 'method' ):
+                    self.start_process_sub_definition( tval, False );  # Is outer sub
                 elif tval in ['BEGIN', 'END', 'AUTOLOAD']:
                     self.skip_anon_sub_contents()
                 elif tval in ['our', 'my', 'state']:
                     if tval == 'state':
                         tval = 'my'
-                    self.get_our_vars('global', tval)
+                    self.get_our_vars( 'global', tval )
                     # Small warning: vars defined at this lexical level belong to
                     # the containing package, but are visible without
                     # qualification in other packages in the same file.
                 elif tval in ['for', 'foreach']:
                     self.get_for_vars()
                 elif tval == 'use':
-                    self.process_use(0)
+                    self.process_use( 0 )
                 elif tval == 'require':
                     origLineNo = tok.start_line
                     tok = self.tokenizer.get_next_token()
                     ttype = tok.style
                     tval = tok.text
-                    if (self.classifier.is_identifier(tok) or
-                        self.classifier.is_variable_scalar(tok,
-                                                           self.classifier.is_scalar_cb)):
+                    if ( self.classifier.is_identifier( tok ) or
+                        self.classifier.is_variable_scalar( tok,
+                                                           self.classifier.is_scalar_cb ) ):
                         # codeintel allows variables
-                        fqModule = self.get_rest_of_subpath(tval, 1)
-                        self.process_import(fqModule, origLineNo)
-                        
-                    elif self.classifier.is_string(tok) and not self.classifier.is_string_qw(tok, self.classifier.is_string_qw_cb):
+                        fqModule = self.get_rest_of_subpath( tval, 1 )
+                        self.process_import( fqModule, origLineNo )
+
+                    elif self.classifier.is_string( tok ) and not self.classifier.is_string_qw( tok, self.classifier.is_string_qw_cb ):
                         # Rewritten to work with UDL languages as well as native perl
-                        self.process_import(tval, origLineNo)
+                        self.process_import( tval, origLineNo )
                 else:
                     self.skip_to_end_of_stmt()
-            elif self.classifier.is_variable_array(tok, self.classifier.is_array_cb):
+            elif self.classifier.is_variable_array( tok, self.classifier.is_array_cb ):
                 if tval == '@ISA':
-                    self.get_parent_namespaces(True)
-                elif tval in ('@EXPORT', '@EXPORT_OK'):
-                    self.get_exported_names(tval)
+                    self.get_parent_namespaces( True )
+                elif tval in ( '@EXPORT', '@EXPORT_OK' ):
+                    self.get_exported_names( tval )
                 else:
-                    self.look_for_var_assignment(tok)
-            elif self.classifier.is_any_operator(tok):
+                    self.look_for_var_assignment( tok )
+            elif self.classifier.is_any_operator( tok ):
                 if tval == '{':
-                    self.process_package_inner_contents(False)
+                    self.process_package_inner_contents( False )
                 elif tval == '}':
                     if not doingTopLevel:
                         if popNS:
-                            self.moduleInfo.doEndNS(lineNo=curr_pkg_line_no)
-                            self.moduleInfo.doStartNS(currPackage)
+                            self.moduleInfo.doEndNS( lineNo = curr_pkg_line_no )
+                            self.moduleInfo.doStartNS( currPackage )
                         break
-            elif self.classifier.is_variable_scalar(tok, self.classifier.is_scalar_cb):
-                self.look_for_object_var_assignment(tok, False)
-            elif self.classifier.is_variable(tok):
+            elif self.classifier.is_variable_scalar( tok, self.classifier.is_scalar_cb ):
+                self.look_for_object_var_assignment( tok, False )
+            elif self.classifier.is_variable( tok ):
                 if tval == '%EXPORT_TAGS':
                     pass
                 else:
-                    self.look_for_var_assignment(tok)
-            elif self.classifier.is_comment_structured(tok, self.classifier.is_pod_cb):
-                self.moduleInfo.currentNS.hDocs['modules'].append(tval)
-            
+                    self.look_for_var_assignment( tok )
+            elif self.classifier.is_comment_structured( tok, self.classifier.is_pod_cb ):
+                self.moduleInfo.currentNS.hDocs['modules'].append( tval )
+
             curr_pkg_line_no = self.tokenizer.curr_line_no()
     # end process_package_inner_contents
-    
-    def process_sub_contents(self, isInnerSub):
+
+    def process_sub_contents( self, isInnerSub ):
         # Get to the open brace or semicolon (outside the parens)
         braceCount = 0
         parenCount = 0
@@ -1557,31 +1557,31 @@ class Parser:
             # Expect a paren for args, the open-brace, or a semi-colon
             tval = tok.text
             if parenCount > 0:
-                if self.classifier.is_operator(tok, ")"):
+                if self.classifier.is_operator( tok, ")" ):
                     parenCount -= 1
-            elif self.classifier.is_any_operator(tok):
-                if tval  == "(":
+            elif self.classifier.is_any_operator( tok ):
+                if tval == "(":
                     parenCount += 1
                 elif tval == "{":
                     braceCount = 1
                     break
                 elif tval == ';':
                     return
-    
+
         # So now look for these different things:
         # '}' taking us to brace count of 0
         # my, name, =, shift;
         # my (..., ..., ...) = @_;
         # bless => mark this as a constructor
         # return => try to figure out what we're looking at
-    
+
         while True:
             tok = self.tokenizer.get_next_token()
             ttype = tok.style
             if ttype == SCE_PL_UNUSED:
                 break
             tval = tok.text
-            if self.classifier.is_index_op(tok):
+            if self.classifier.is_index_op( tok ):
                 if tval == "{":
                     braceCount += 1
                 elif tval == "}":
@@ -1592,25 +1592,25 @@ class Parser:
                     # Stay here -- it indicates a label
                     pass
                 else:
-                    self.tokenizer.put_back(tok)
+                    self.tokenizer.put_back( tok )
                     self.skip_to_end_of_stmt()
             elif ttype == self.classifier.style_word:
                 tlineNo = tok.start_line
-                if tval in ('my', 'state'):
+                if tval in ( 'my', 'state' ):
                     tok = self.tokenizer.get_next_token()
-                    if self.classifier.is_operator(tok, '('):
+                    if self.classifier.is_operator( tok, '(' ):
                         # Treat 'state' variables as 'my', as both
                         # are only visible locally.
-                        self.collect_multiple_args(tlineNo, 'local', 'my')
-                    elif self.classifier.is_variable(tok):
-                        self.collect_single_arg(tok.text, tlineNo, 'local', 'my')
-                        if self.classifier.is_operator(tok, '{'):
+                        self.collect_multiple_args( tlineNo, 'local', 'my' )
+                    elif self.classifier.is_variable( tok ):
+                        self.collect_single_arg( tok.text, tlineNo, 'local', 'my' )
+                        if self.classifier.is_operator( tok, '{' ):
                             braceCount += 1
                     else:
-                        self.get_our_vars('local', 'my')
-                elif tval in ('for', 'foreach'):
+                        self.get_our_vars( 'local', 'my' )
+                elif tval in ( 'for', 'foreach' ):
                     self.get_for_vars()
-                    if self.classifier.is_operator(tok, '{'):
+                    if self.classifier.is_operator( tok, '{' ):
                         braceCount += 1
                 elif tval == 'bless':
                     self.moduleInfo.currentFunction.isConstructor = True
@@ -1620,100 +1620,100 @@ class Parser:
                     # Either it returned an identifier, or it put the token back
                     tok = self.tokenizer.get_next_token()
                     ttype = tok.style
-                    if self.classifier.is_identifier(tok):
-                        subclass = self.get_rest_of_subpath(tok.text, 1)
+                    if self.classifier.is_identifier( tok ):
+                        subclass = self.get_rest_of_subpath( tok.text, 1 )
                         tok = self.tokenizer.get_next_token()
                         if tok.text != '->':
-                            self.tokenizer.put_back(tok)
+                            self.tokenizer.put_back( tok )
                         else:
                             tok = self.tokenizer.get_next_token()
                             if tok.text == 'new':
                                 if self.moduleInfo.currentFunction:
-                                    self.moduleInfo.currentFunction.resultType.append(subclass)
+                                    self.moduleInfo.currentFunction.resultType.append( subclass )
                             else:
-                                self.tokenizer.put_back(tok)
+                                self.tokenizer.put_back( tok )
                     else:
-                        self.tokenizer.put_back(tok)
+                        self.tokenizer.put_back( tok )
                 elif tval == 'require':
                     tok = self.tokenizer.get_next_token()
                     ttype = tok.style
-                    if self.classifier.is_identifier(tok):
+                    if self.classifier.is_identifier( tok ):
                         origLineNo = tok.start_line
-                        fqModule = self.get_rest_of_subpath(tok.text, 1)
-                        self.process_import(fqModule, origLineNo)
+                        fqModule = self.get_rest_of_subpath( tok.text, 1 )
+                        self.process_import( fqModule, origLineNo )
                 elif tval == 'use':
-                    self.process_use(1)
-                elif tval == 'sub':
+                    self.process_use( 1 )
+                elif tval in ( 'sub', 'func', 'method' ):
                     # Nested subs in Perl aren't really nested --
                     # They're kind of like named closures -- accessible
                     # by name from an outer context, but they can bind
                     # the local state of the sub when defined.
                     # But we can call them anyway, so let's process them
-    
-                    self.start_process_sub_definition(True) # Is inner
+
+                    self.start_process_sub_definition( tval, True )  # Is inner
                 else:
                     self.skip_to_end_of_stmt()
-            elif self.classifier.is_variable_scalar(tok, self.classifier.is_scalar_cb):
-                self.look_for_object_var_assignment(tok, isInnerSub)
-            elif self.classifier.is_variable(tok):
+            elif self.classifier.is_variable_scalar( tok, self.classifier.is_scalar_cb ):
+                self.look_for_object_var_assignment( tok, isInnerSub )
+            elif self.classifier.is_variable( tok ):
                 if tval == '%EXPORT_TAGS':
                     pass
                 else:
-                    self.look_for_var_assignment(tok)
-            elif self.classifier.is_comment_structured(tok, self.classifier.is_pod_cb):
+                    self.look_for_var_assignment( tok )
+            elif self.classifier.is_comment_structured( tok, self.classifier.is_pod_cb ):
                 if self.moduleInfo.currentFunction:
-                    name = getattr(self.moduleInfo.currentFunction, 'name', None)
+                    name = getattr( self.moduleInfo.currentFunction, 'name', None )
                     if name:
                         # hdoc_subs = self.moduleInfo.currentNS.hDocs['subs']
-                        self.moduleInfo.set_or_append(self.moduleInfo.currentNS.hDocs['subs'], name, tval)
+                        self.moduleInfo.set_or_append( self.moduleInfo.currentNS.hDocs['subs'], name, tval )
         # end while
     # end process_sub_contents
 
-    def process_use(self, local):
+    def process_use( self, local ):
         tok = self.tokenizer.get_next_token()
-        if self.classifier.is_identifier_or_keyword(tok):
+        if self.classifier.is_identifier_or_keyword( tok ):
             origLineNo = tok.start_line
             #@@@ RE
-            if re_compile('^[a-z]+$').match(tok.text):
+            if re_compile( '^[a-z]+$' ).match( tok.text ):
                 if tok.text == 'vars':
-                    self.get_used_vars(local and 'local' or 'global')
+                    self.get_used_vars( local and 'local' or 'global' )
                     return
                 elif tok.text == 'base':
                     if not local:
-                        self.get_parent_namespaces(False)
+                        self.get_parent_namespaces( False )
                     return
-                elif self.pragmaNames.has_key(tok.text):
+                elif self.pragmaNames.has_key( tok.text ):
                     firstMod = tok.text
                     tok = self.tokenizer.get_next_token()
-                    if not self.classifier.is_operator(tok, "::"):
-                        self.tokenizer.put_back(tok)
+                    if not self.classifier.is_operator( tok, "::" ):
+                        self.tokenizer.put_back( tok )
                         return
-                    self.tokenizer.put_back(tok)
+                    self.tokenizer.put_back( tok )
                     tval = firstMod
                 else:
                     tval = tok.text
             else:
                 tval = tok.text
-            fqModule = self.get_rest_of_subpath(tval, 1)
-            self.process_import(fqModule, origLineNo, import_vars=1)
+            fqModule = self.get_rest_of_subpath( tval, 1 )
+            self.process_import( fqModule, origLineNo, import_vars = 1 )
     # end process_use
 
-    def skip_anon_sub_contents(self):
+    def skip_anon_sub_contents( self ):
         tok = self.tokenizer.get_next_token()
-        if self.classifier.is_operator(tok, "{"):
-            self.process_package_inner_contents(False)
+        if self.classifier.is_operator( tok, "{" ):
+            self.process_package_inner_contents( False )
     # end skip_anon_sub_contents
 
-    def skip_to_close_match(self):
+    def skip_to_close_match( self ):
         nestedCount = 1
         while 1:
             tok = self.tokenizer.get_next_token()
             ttype = tok.style
             if ttype == SCE_PL_UNUSED:
                 return
-            elif self.classifier.is_index_op(tok):
+            elif self.classifier.is_index_op( tok ):
                 tval = tok.text
-                if self.opHash.has_key(tval):
+                if self.opHash.has_key( tval ):
                     if self.opHash[tval][1] == 1:
                         nestedCount += 1
                     else:
@@ -1721,15 +1721,15 @@ class Parser:
                         if nestedCount <= 0:
                             break
     # end get_rest_of_subpath
-    
-    def skip_to_close_paren(self):
+
+    def skip_to_close_paren( self ):
         tok = self.tokenizer.get_next_token()
         nestedCount = 1
         while 1:
             ttype = tok.style
             if ttype == SCE_PL_UNUSED:
                 return
-            elif self.classifier.is_any_operator(tok):
+            elif self.classifier.is_any_operator( tok ):
                 tval = tok.text
                 if tval == "(":
                     nestedCount += 1
@@ -1742,21 +1742,21 @@ class Parser:
                     tok = self.tokenizer.get_next_token()
             else:
                 tok = self.tokenizer.get_next_token()
-    #end skip_to_close_paren
-    
-    def skip_to_end_of_stmt(self):
+    # end skip_to_close_paren
+
+    def skip_to_end_of_stmt( self ):
         nestedCount = 0
         while 1:
             tok = self.tokenizer.get_next_token()
             ttype = tok.style
             if ttype == SCE_PL_UNUSED:
                 break
-            if self.classifier.is_index_op(tok):
+            if self.classifier.is_index_op( tok ):
                 tval = tok.text
-                if self.opHash.has_key(tval):
+                if self.opHash.has_key( tval ):
                     if tval == "{":
                         if nestedCount == 0:
-                            self.tokenizer.put_back(tok)
+                            self.tokenizer.put_back( tok )
                             # At an open-brace, keep going.
                             break
                     vals = self.opHash[tval]
@@ -1767,7 +1767,7 @@ class Parser:
                         if nestedCount <= 0:
                             nestedCount = 0
                             if tval == "}":
-                                self.tokenizer.put_back(tok)
+                                self.tokenizer.put_back( tok )
                                 break
                 elif tval == ";":
                      # Don't worry about commas, since they don't separate
@@ -1775,108 +1775,146 @@ class Parser:
                     if nestedCount == 0:
                         break
     # end skip_to_end_of_stmt
-    
-    def start_process_sub_definition(self, isInnerSub):
+
+    def start_process_sub_definition( self, funcType, isInnerSub ):
         tok = self.tokenizer.get_next_token()
         # Watch out for lexer buffoonery
-        if self.classifier.is_identifier(tok) and len(tok.text.strip()) == 0:
+        if self.classifier.is_identifier( tok ) and len( tok.text.strip() ) == 0:
             tok = self.tokenizer.get_next_token()
-        if (self.classifier.is_operator(tok, "{") or
-            not self.classifier.is_identifier_or_keyword(tok)):
-            self.tokenizer.put_back(tok)
+        if ( self.classifier.is_operator( tok, "{" ) or
+            not self.classifier.is_identifier_or_keyword( tok ) ):
+            self.tokenizer.put_back( tok )
             self.skip_to_end_of_stmt()
         else:
             startLineNo = tok.start_line
-            fnName = self.get_rest_of_subpath(tok.text, 0)
+            fnName = self.get_rest_of_subpath( tok.text, 0 )
             if fnName:
                 tok = self.tokenizer.get_next_token()
-                if self.classifier.is_operator(tok, "("):
+                parseArgs = False
+                if self.classifier.is_operator( tok, "(" ) and funcType not in ( 'func', 'method' ):
                     self.skip_to_close_paren()
                     tok = self.tokenizer.get_next_token()
-                if self.classifier.is_operator(tok, ";"):
+                    parseArgs = False
+                else:
+                    parseArgs = True
+
+                if self.classifier.is_operator( tok, ";" ):
                     # Don't process
                     pass
                 else:
-                    self.tokenizer.put_back(tok)
+                    if not parseArgs:
+                        self.tokenizer.put_back( tok )
+
                     # Python doesn't have Perl's localizer, so we do this manually.
                     currFunction = self.moduleInfo.currentFunction
-                    self.moduleInfo.doStartFn(FunctionInfo(name=fnName.strip(), lineNo=startLineNo))
-                    self.process_sub_contents(isInnerSub)
-                    self.moduleInfo.doEndFn(lineNo=self.tokenizer.curr_line_no())
+                    self.moduleInfo.doStartFn( FunctionInfo( name = fnName.strip(), lineNo = startLineNo ) )
+
+                    if parseArgs:
+                        nameList = []
+                        isOptional = False
+                        while True:
+                            tok = self.tokenizer.get_next_token()
+                            if self.classifier.is_variable( tok ):
+                                if isOptional:
+                                    nameList.append( "[" + tok.text + "]" )
+                                else:
+                                    nameList.append( tok.text )
+                                isOptional = False
+
+                            elif self.classifier.is_operator( tok, "," ):
+                                continue
+                            elif self.classifier.is_operator( tok, ":" ):
+                                isOptional = True
+                            else:
+                                break
+
+                        for argName in nameList:
+                            self.moduleInfo.doSetArg( argName )
+
+                        if funcType == "method":
+                            args = {'name':"$self", 'line':tok.start_line,
+                                    "aType": { "assign" : self.moduleName}, "scope": "local",
+                                    "context": "my"}
+                            self.moduleInfo.doSetVar( **args )
+
+
+                    self.process_sub_contents( isInnerSub )
+                    self.moduleInfo.doEndFn( lineNo = self.tokenizer.curr_line_no() )
                     self.moduleInfo.currentFunction = currFunction
             else:
                 self.skipAnonSubContents()
     # end start_process_sub_definition
-        
+
 # end class Parser
 
-def pp(etree, fd):
-    s = tostring(etree)
+def pp( etree, fd ):
+    s = tostring( etree )
     ind = 0
     iw = 4
     need_nl = False
-    #actual_empty_tag_ptn = re_compile(r'<(\w[-\w\d_.]*)([^>]+?)>\s*</\1>', re.S)
-    tags = [(re_compile(r'<\?.*?\?>', re.S), False, 0, False),
-            (re_compile(r'<!--.*?-->', re.S), False, 0, False),
-            (re_compile(r'</[^>]+?>', re.S), True, 0, True), # update before emitting newline
-            (re_compile(r'<[^>]+?/>', re.S), True, 0, False),
-            (re_compile(r'<[^>]+?>', re.S), True, 1, True),# update after emitting newline
+    # actual_empty_tag_ptn = re_compile(r'<(\w[-\w\d_.]*)([^>]+?)>\s*</\1>', re.S)
+    tags = [( re_compile( r'<\?.*?\?>', re.S ), False, 0, False ),
+            ( re_compile( r'<!--.*?-->', re.S ), False, 0, False ),
+            ( re_compile( r'</[^>]+?>', re.S ), True, 0, True ),  # update before emitting newline
+            ( re_compile( r'<[^>]+?/>', re.S ), True, 0, False ),
+            ( re_compile( r'<[^>]+?>', re.S ), True, 1, True ),  # update after emitting newline
             ]
-    fd.write("""<?xml version="1.0" encoding="UTF-8"?>\n""")
-    while len(s) > 0:
+    fd.write( """<?xml version="1.0" encoding="UTF-8"?>\n""" )
+    while len( s ) > 0:
         if need_nl:
             if s[0:1] == "\r\n":
                 s = s[2:]
             elif s[0] == "\n":
                 s = s[1:]
-            fd.write("\n" + ' ' * (ind * iw))
+            fd.write( "\n" + ' ' * ( ind * iw ) )
             need_nl = False
-        ltpt = s.find("<")
+        ltpt = s.find( "<" )
         if ltpt < 0:
-            fd.write(s)
+            fd.write( s )
             break
-        fd.write(s[0:ltpt])
+        fd.write( s[0:ltpt] )
         s = s[ltpt:]
-        #m = actual_empty_tag_ptn.match(s)
-        #if m:
+        # m = actual_empty_tag_ptn.match(s)
+        # if m:
         #    print "<%s%s />" % (m.group(1), m.group(2)),
         #    need_nl = True
         #    s = s[len(m.group(1)):]
         #    continue
         for tt in tags:
-            m = tt[0].match(s)
+            m = tt[0].match( s )
             if m:
-                tag_end_idx = len(m.group(0))
+                tag_end_idx = len( m.group( 0 ) )
                 need_nl = tt[1]
-                if tt[3] and len(s) > tag_end_idx and s[tag_end_idx] != "<":
-                    gtpt = s.find(">", tag_end_idx)
-                    fd.write(s[0:gtpt+1])
-                    s = s[gtpt+1:]
+                if tt[3] and len( s ) > tag_end_idx and s[tag_end_idx] != "<":
+                    gtpt = s.find( ">", tag_end_idx )
+                    fd.write( s[0:gtpt + 1] )
+                    s = s[gtpt + 1:]
                 else:
                     ind += tt[2]
-                    fd.write(s[:tag_end_idx])
+                    fd.write( s[:tag_end_idx] )
                     s = s[tag_end_idx:]
                 # Preview end-tag breaking
-                if s.startswith("</"):
+                if s.startswith( "</" ):
                     need_nl = True
                     if ind > 0:
                         ind -= 1
                 break
         else:
-            fd.write(s[0:ltpt+1])
-            s = s[ltpt+1:]
+            fd.write( s[0:ltpt + 1] )
+            s = s[ltpt + 1:]
 
-def main(sample_code, modulePath, mtime, showWarnings, provide_full_docs=True):
-    sys.stderr.write("Skipping POD: %r\n" % provide_full_docs)
-    sys.exit(1)
-    tokenizer = perl_lexer.PerlLexer(sample_code, provide_full_docs)
-    parser = Parser(tokenizer, provide_full_docs)
-    showWarnings = False
-    elementTreeRepn = parser.process_module(modulePath, mtime, showWarnings)
+def main( sample_code, modulePath, mtime, showWarnings, provide_full_docs = True ):
+#     sys.stderr.write("Skipping POD: %r\n" % provide_full_docs)
+#     sys.exit(1)
+    tokenizer = perl_lexer.PerlLexer( sample_code, provide_full_docs )
+    parser = Parser( tokenizer, provide_full_docs = provide_full_docs )
+    showWarnings = True
+    elementTreeRepn = parser.process_module( modulePath, mtime, showWarnings )
+
     return elementTreeRepn
-        
+
 if __name__ == "__main__":
-    if len(sys.argv) == 1:
+    if len( sys.argv ) == 1:
         sample_code = perl_lexer.provide_sample_code()
         fs = None
         closefs = False
@@ -1889,23 +1927,23 @@ if __name__ == "__main__":
         mtime = time.time()
     else:
         modulePath = sys.argv[1]
-        mtime = os.stat(modulePath).st_mtime
-        fs = open(modulePath, "r")
+        mtime = os.stat( modulePath ).st_mtime
+        fs = open( modulePath, "r" )
         closefs = True
     if fs is not None:
-        sample_code = shared_lexer.read_and_detab(fs, closefs)
+        sample_code = shared_lexer.read_and_detab( fs, closefs )
         # fs comes back closed
     # Don't show the data
-    elementTreeRepn = main(sample_code, modulePath, mtime, showWarnings, False)
-    sys.stdout.write(tostring(elementTreeRepn))
-    sys.stdout.write("\n")
+    elementTreeRepn = main( sample_code, modulePath, mtime, showWarnings, True )
+#     sys.stdout.write(tostring(elementTreeRepn))
+#     sys.stdout.write("\n")
 
-    #pp(elementTreeRepn, sys.stdout)
-    #import hotshot, hotshot.stats
-    #profiler = hotshot.Profile("%s.prof" % (__file__))
-    #profiler.runcall(main, sample_code, modulePath, mtime, showWarnings)
-    #regex_data = REGEXEN.items()
-    #regex_data.sort(lambda a, b: -cmp(a[1], b[1]))
-    #for x in regex_data[:20]:
+    pp( elementTreeRepn, sys.stdout )
+    # import hotshot, hotshot.stats
+    # profiler = hotshot.Profile("%s.prof" % (__file__))
+    # profiler.runcall(main, sample_code, modulePath, mtime, showWarnings)
+    # regex_data = REGEXEN.items()
+    # regex_data.sort(lambda a, b: -cmp(a[1], b[1]))
+    # for x in regex_data[:20]:
     #    print x[1], x[0]
 

--- a/libs/codeintel2/perl_parser.py
+++ b/libs/codeintel2/perl_parser.py
@@ -1484,7 +1484,10 @@ class Parser:
                                                    lineNo=self.tokenizer.curr_line_no())
                         self.moduleInfo.doStartNS(ns)
                         popNS = 1
-                elif tval == 'sub':
+                elif tval in ['sub', 'func', 'method']:
+                    if tval in ['func', 'method']:
+                        tval = 'sub'
+
                     self.start_process_sub_definition(False); # Is outer sub
                 elif tval in ['BEGIN', 'END', 'AUTOLOAD']:
                     self.skip_anon_sub_contents()
@@ -1643,7 +1646,9 @@ class Parser:
                         self.process_import(fqModule, origLineNo)
                 elif tval == 'use':
                     self.process_use(1)
-                elif tval == 'sub':
+                elif  tval in ['sub', 'func', 'method']:
+                    if tval in ['func', 'method']:
+                        tval = 'sub'
                     # Nested subs in Perl aren't really nested --
                     # They're kind of like named closures -- accessible
                     # by name from an outer context, but they can bind

--- a/libs/codeintel2/perl_parser.py
+++ b/libs/codeintel2/perl_parser.py
@@ -86,19 +86,20 @@ def memoize( function, limit = None ):
 
         return memoize_wrapper
     else:
-    dict = {}
-    list = []
+        dict = {}
+        list = []
+
         def memoize_wrapper( *args, **kwargs ):
             key = cPickle.dumps( ( args, kwargs ) )
-        try:
+            try:
                 list.append( list.pop( list.index( key ) ) )
-        except ValueError:
+            except ValueError:
                 dict[key] = function( *args, **kwargs )
                 list.append( key )
                 if limit is not None and len( list ) > limit:
                     del dict[list.pop( 0 )]
 
-        return dict[key]
+            return dict[key]
 
     memoize_wrapper._memoize_dict = dict
     memoize_wrapper._memoize_list = list

--- a/src/build.sh
+++ b/src/build.sh
@@ -8,6 +8,9 @@ if [ $OSTYPE = "linux-gnu" ]; then
 	fi
 fi
 export LDFLAGS='-L/tmp/pcre-8.21/.libs'
+export CPATH='/tmp/pcre-8.21/'
+export CFLAGS='-I/tmp/pcre-8.21'
+
 rm -rf cElementTree-1.0.5-20051216 && \
 rm -rf silvercity && \
 rm -rf scintilla && \

--- a/src/scintilla.patch/lexers/LexPerl.cxx
+++ b/src/scintilla.patch/lexers/LexPerl.cxx
@@ -1867,7 +1867,10 @@ void ColourisePerlDoc(unsigned int startPos, int length, int , // initStyle
                         ch = ' ';
                     
                         // Recognise the beginning of a subroutine - enter the SUB state.
-                        if (kwdStartPos+2 == i && isMatch(styler, lengthDoc, kwdStartPos, "sub")) { 
+                        if (kwdStartPos+2 == i && (
+                            isMatch(styler, lengthDoc, kwdStartPos, "sub") || 
+                            isMatch(styler, lengthDoc, kwdStartPos, "func") || 
+                            isMatch(styler, lengthDoc, kwdStartPos, "method") ) ) {
                             for (unsigned int j = i+1;j < lengthDoc;j++) {
                                 char c = styler.SafeGetCharAt(j);
                                 if (!isspacechar(c)) {


### PR DESCRIPTION
Hi,

Could you please accept my change - I added support for Method::Signatures into a perl parser. Now they recognize functions definition in 3 forms:
Standard: 

```
sub function {
 my @args = @_;
 ... logic here
}
```

Introduced by the package:

```
func function ( $var1, $var2, $var3 ) {
... login here
}
```

```
method function ( $var1, $var2, $var3 ) {
... logic here
}
```

method is a keyword for class methods.

There is also a minor fix in build.sh: it fails to build because for some reason there was no a reference to pcre.h and clang died on that.

Thanks,
Dmitry
