### PR TITLE
Fixed bug in saving status_msg. This was causing status_msg to never be ...

### DIFF
--- a/SublimeCodeIntel.py
+++ b/SublimeCodeIntel.py
@@ -191,7 +191,7 @@ def calltip(view, type, msg=None, timeout=None, delay=0, id='CodeIntel', logger=
                     (logger or log.info)(msg)
                 else:
                     view.erase_status(id)
-                status_msg[id][0] = [type, msg, order]
+                status_msg[id] = [type, msg, order]
                 if 'warning' not in id and msg:
                     status_lineno[id] = lineno
                 elif id in status_lineno:
@@ -266,9 +266,9 @@ def guess_lang(view=None, path=None):
 
     if not lang and _lang and _lang not in ('Console',):
         if mgr:
-            logger(view, 'info', "Invalid language: %s. Available: %s" % (_lang, ', '.join(set(mgr.get_citadel_langs() + mgr.get_cpln_langs()))))
+            logger(view, 'info', "Invalid language: %s. Available: %s" % (_lang, ', '.join(set(mgr.get_citadel_langs() + mgr.get_cpln_langs()))), 5000)
         else:
-            logger(view, 'info', "Invalid language: %s" % _lang)
+            logger(view, 'info', "Invalid language: %s" % _lang, 5000)
 
     languages[id][_k_] = lang
     return lang


### PR DESCRIPTION
...erased. Also setting an explicit 5 second timeout to really long Invalid language status message.

This is to address https://github.com/Kronuz/SublimeCodeIntel/issues/104

The logger/calltip functions already has a timeout. There was a bug that was preventing the status message from ever being erased properly. Also, I think this message is "info" if not "debug" level, but I think 10 seconds is too long since this messages is extremely verbose and takes over the entire status line. The options were to either change the message type to "warning" or "error", or to provide an explicit timeout amount for less than 10 seconds.

I don't think changing the message type to warning or error is the right thing because it's not a warning or an error situation, it's just the plugin saying "I couldn't do anything with this file".

So I chose to provide an explicit timeout for 5 seconds for this one message.

Hope this helps!
