### PR TITLE
Updated repository url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,11 +26,11 @@ Installing
 
 Once you install Package Control, restart ST2 and bring up the Command Palette (``Command+Shift+P`` on OS X, ``Control+Shift+P`` on Linux/Windows). Select "Package Control: Install Package", wait while Package Control fetches the latest package list, then select SublimeCodeIntel when the list appears. The advantage of using this method is that Package Control will automatically keep SublimeCodeIntel up to date with the latest version.
 
-**Without Git:** Download the latest source from `GitHub <http://github.com/Kronuz/SublimeCodeIntel>`_ and copy the whole directory into the Packages directory.
+**Without Git:** Download the latest source from `GitHub <http://github.com/SublimeCodeIntel/SublimeCodeIntel>`_ and copy the whole directory into the Packages directory.
 
 **With Git:** Clone the repository in your Sublime Text 2 Packages directory, located somewhere in user's "Home" directory::
 
-    git clone git://github.com/Kronuz/SublimeCodeIntel.git
+    git clone git://github.com/SublimeCodeIntel/SublimeCodeIntel.git
 
 
 The "Packages" packages directory is located at:

--- a/libs/codeintel2/database/database.py
+++ b/libs/codeintel2/database/database.py
@@ -456,7 +456,7 @@ class Database(object):
                 subsystem of SublimeCodeIntel). Do NOT modify anything in here
                 unless you know what you are doing.
 
-                See http://github.com/Kronuz/SublimeCodeIntel for details.
+                See http://github.com/SublimeCodeIntel/SublimeCodeIntel for details.
             """))
             open(join(self.base_dir, "VERSION"), 'w').write(self.VERSION)
             config_file = join(self.base_dir, "config")

--- a/package_control.json
+++ b/package_control.json
@@ -5,7 +5,7 @@
             "name": "SublimeCodeIntel",
             "description": "Full-featured code intelligence and smart autocomplete engine",
             "author": "Kronuz",
-            "homepage": "http://github.com/Kronuz/SublimeCodeIntel",
+            "homepage": "http://github.com/SublimeCodeIntel/SublimeCodeIntel",
             "last_modified": "2011-12-20 19:01:17",
             "platforms": {
                 "*": [

--- a/src/openkomodo.patch/database-sublime_legend.patch
+++ b/src/openkomodo.patch/database-sublime_legend.patch
@@ -15,7 +15,7 @@
 +                unless you know what you are doing.
  
 -                See http://www.activestate.com/Products/Komodo/ for details.
-+                See http://github.com/Kronuz/SublimeCodeIntel for details.
++                See http://github.com/SublimeCodeIntel/SublimeCodeIntel for details.
              """))
              open(join(self.base_dir, "VERSION"), 'w').write(self.VERSION)
 +            config_file = join(self.base_dir, "config")


### PR DESCRIPTION
Updated all old urls "Kronuz/SublimeCodeIntel" to new one "SublimeCodeIntel/SublimeCodeIntel" except package control url (I think package control version update should stay in separate commit).
This PR also contains change from #243 but corrects all old urls inside package.
