### PR TITLE
Revert 51f5017. Fixes #271.

### DIFF
--- a/SublimeCodeIntel.py
+++ b/SublimeCodeIntel.py
@@ -900,7 +900,6 @@ ALL_SETTINGS = [
     'codeintel_syntax_map',
     'codeintel_scan_exclude_dir',
     'codeintel_config',
-    'sublime_auto_complete',
 ]
 
 
@@ -923,9 +922,6 @@ def reload_settings(view):
 
     if view_settings.get('codeintel') is None:
         view_settings.set('codeintel', True)
-
-    if not view_settings.get('sublime_auto_complete'):
-        view_settings.set('auto_complete', False)
 
     return view_settings
 

--- a/SublimeCodeIntel.sublime-settings
+++ b/SublimeCodeIntel.sublime-settings
@@ -10,9 +10,6 @@
     */
     "codeintel": true,
 
-    /* Disable Sublime Text autocomplete: */
-    "sublime_auto_complete": false,
-
     /*
         Insert functions snippets.
     */


### PR DESCRIPTION
Disabling sublime_auto_complete in the settings causes autocomplete to not work at all. Even with files/languages supported by SublimeCodeIntel. This commit simply re-enables sublime_autocomplete and reverts commit 51f5017. I've tested on Mac OS X 10.8.4 and Sublime Text 2.0.2 build 2221. For that platform, it fixes the issue.
