### PR TITLE
fix creating '%USERPROFILE%\\.codeintel' directory problem on Windows

### DIFF
--- a/libs/codeintel2/database/database.py
+++ b/libs/codeintel2/database/database.py
@@ -244,7 +244,7 @@ class).
 
 import sys
 import os
-from os.path import (join, dirname, exists, expanduser, splitext, basename,
+from os.path import (join, dirname, exists, expanduser, expandvars, splitext, basename,
                      split, abspath, isabs, isdir, isfile)
 import cPickle as pickle
 from cPickle import UnpicklingError
@@ -390,7 +390,7 @@ class Database(object):
         self._proj_zone_from_proj_path = weakref.WeakValueDictionary()
 
         if base_dir is None:
-            self.base_dir = expanduser(join("~", ".codeintel"))
+            self.base_dir = expandvars(expanduser(join("~", ".codeintel")))
         elif not isabs(base_dir):
             self.base_dir = abspath(base_dir)
         else:


### PR DESCRIPTION
i dont know if there is the same problem on linux
