### PR TITLE
Fix error in tooltip caused by trailing whitespace on variable name

### DIFF
--- a/SublimeCodeIntel.py
+++ b/SublimeCodeIntel.py
@@ -204,6 +204,7 @@ def tooltip(view, calltips, original_pos):
                 for i, p in enumerate(params):
                     if p:
                         var, _, _ = p.partition('=')
+                        var = var.strip()
                         if ' ' in var:
                             var = var.split(' ')[1]
                         if var[0] == '$':


### PR DESCRIPTION
Fixes this error

```
[2013-09-19 20:41:37,440 - INFO - codeintel] _hit_from_citdl:: found 'HabBusinessPeer.retrieveByBSubcategory' => <Element 'scope' at 0x7f88ac35dcf8> on (<Element 'scope' at 0x7f889cec26e0>, ['HabBusinessPeer'])
[2013-09-19 20:41:37,440 - INFO - codeintel]     calltips: ["retrieveByBSubcategory($bsubcategory_id, $state = '', $page = 1, $max = 10, $bcategory_id = false)"]
[2013-09-19 20:41:37,440 - INFO - codeintel] done eval: success
[2013-09-19 20:41:37,443 - INFO - codeintel] Autocomplete called (PHP) [calltips]
Traceback (most recent call last):
  File "/home/hugo/.config/sublime-text-3/Packages/SublimeCodeIntel/SublimeCodeIntel.py", line 882, in _callback
    callback(*ret)
  File "/home/hugo/.config/sublime-text-3/Packages/SublimeCodeIntel/SublimeCodeIntel.py", line 404, in _trigger
    tooltip(view, calltips, original_pos)
  File "/home/hugo/.config/sublime-text-3/Packages/SublimeCodeIntel/SublimeCodeIntel.py", line 209, in tooltip
    if var[0] == '$':
IndexError: string index out of range
```
