### PR TITLE
Added command to trigger autocomplete

### DIFF
--- a/SublimeCodeIntel.py
+++ b/SublimeCodeIntel.py
@@ -535,6 +535,18 @@ class SublimeCodeIntel(CodeIntelHandler, sublime_plugin.EventListener):
         return cplns
 
 
+class CodeIntelAutoComplete(CodeIntelHandler, sublime_plugin.TextCommand):
+    def run(self, edit, block=False):
+        view = self.view
+
+        buf = self.buf_from_view(view)
+
+        if not buf:
+            return
+        buf.scan_document(self, True)
+        buf.trg_from_pos(self, True)
+
+
 class GotoPythonDefinition(CodeIntelHandler, sublime_plugin.TextCommand):
     def run(self, edit, block=False):
         view = self.view


### PR DESCRIPTION
Added a command to trigger autocomplete.
The name of the command is the same as the one that exists in SublimeCodeIntel v2 (key mapping already exists in SublimeCodeIntel v3).