### PR TITLE
Removed unnecessary items of Main.sublime-menu

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,36 +1,32 @@
 [
     {
-        "caption": "Preferences",
+        "id": "preferences",
         "children": [
             {
-                "caption": "Package Settings",
+                "id": "package-settings",
                 "children": [
                     {
                         "caption": "SublimeCodeIntel",
+                        "id": "sublimecodeintel",
                         "children": [
                             {
+                                "caption": "Settings \u2013 Default",
+                                "command": "open_file",
                                 "args": {
                                     "file": "${packages}/SublimeCodeIntel/SublimeCodeIntel.sublime-settings"
-                                },
-                                "caption": "Settings \u2013 Default",
-                                "command": "open_file"
+                                }
                             },
                             {
+                                "caption": "Settings \u2013 User",
+                                "command": "open_file",
                                 "args": {
                                     "file": "${packages}/User/SublimeCodeIntel.sublime-settings"
-                                },
-                                "caption": "Settings \u2013 User",
-                                "command": "open_file"
+                                }
                             }
                         ],
-                        "id": "sublimecodeintel"
                     }
                 ],
-                "id": "package-settings",
-                "mnemonic": "P"
             }
         ],
-        "id": "preferences",
-        "mnemonic": "n"
     }
 ]


### PR DESCRIPTION
Translations are not displayed in the localization plugin installed environment.